### PR TITLE
docs: add PR template, issue templates, and full contribution/security guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Report something that is broken or behaving unexpectedly
+title: "fix: "
+labels: bug
+assignees: ""
+---
+
+## Describe the bug
+
+<!-- A clear and concise description of what the bug is. -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+<!-- What should have happened? -->
+
+## Actual behavior
+
+<!-- What happened instead? -->
+
+## Environment
+
+- **Browser**: <!-- e.g. Chrome 124, Edge 122 -->
+- **OS**: <!-- e.g. macOS 14, Windows 11, Ubuntu 24 -->
+- **Node.js version** (if running locally): <!-- e.g. 20.11 -->
+
+## Screenshots / console errors
+
+<!-- Paste any relevant console errors or attach screenshots. -->
+
+## Additional context
+
+<!-- Anything else that might help diagnose the issue. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,31 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement
+title: "feat: "
+labels: enhancement
+assignees: ""
+---
+
+## Problem statement
+
+<!-- What problem does this feature solve? Who is affected? -->
+
+## Proposed solution
+
+<!-- Describe what you'd like to happen. Be as specific as possible. -->
+
+## Alternatives considered
+
+<!-- Have you considered other approaches? Why is your proposal the best option? -->
+
+## Relevant roadmap phase
+
+<!-- Check the phase this relates to, if any. See PRD or README for the full roadmap. -->
+
+- [ ] Phase 4 — Collaboration (Yjs/CRDT, presence, permissions)
+- [ ] Phase 5 — Polish (search, version history, templates, exports)
+- [ ] Other / not on the roadmap
+
+## Additional context
+
+<!-- Mockups, examples from other tools, related issues, etc. -->

--- a/.github/ISSUE_TEMPLATE/security_report.md
+++ b/.github/ISSUE_TEMPLATE/security_report.md
@@ -1,0 +1,15 @@
+---
+name: Security report
+about: "⚠️ DO NOT use this template for security vulnerabilities — see instructions below"
+title: ""
+labels: ""
+assignees: ""
+---
+
+⚠️ **Do not report security vulnerabilities here.**
+
+Public issues are visible to everyone, including potential attackers.
+
+Please follow the responsible disclosure process described in [SECURITY.md](../../SECURITY.md) and contact the maintainer privately.
+
+**Nathan Kamokoue** — [LinkedIn](https://www.linkedin.com/in/nathan-kamokoue-1289121b8/)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,42 @@
+## Description
+
+<!-- Describe what this PR does and why. Link the related issue if applicable. -->
+
+Closes #<!-- issue number -->
+
+## Type of change
+
+<!-- Check all that apply -->
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that changes existing behavior)
+- [ ] Refactor (no behavior change)
+- [ ] Documentation only
+
+## How to test
+
+<!-- Step-by-step instructions to verify the changes work correctly. -->
+
+1.
+2.
+3.
+
+## Security checklist
+
+<!-- Every PR must pass this checklist before merging. -->
+
+- [ ] No API keys, tokens, or secrets are hardcoded or committed
+- [ ] `.env` is not included in this PR
+- [ ] No new `eval()`, `Function()`, or unsanitized `innerHTML` usage
+- [ ] Any new `dangerouslySetInnerHTML` usage only renders content from trusted internal sources (e.g. Mermaid output), never from user input or external APIs
+- [ ] No new dependencies added without justification in the PR description
+- [ ] New dependencies have been checked for known vulnerabilities (`npm audit`)
+
+## Screenshots / recordings
+
+<!-- If this PR changes the UI, include before/after screenshots or a short screen recording. -->
+
+## Notes for reviewers
+
+<!-- Anything that needs special attention or context during review. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,34 @@
 # Contributing to BlueLens
 
-Thanks for your interest in contributing! BlueLens is a living architecture diagram platform built with React and TypeScript.
+Thanks for your interest in contributing! This document covers everything you need to know to submit a quality contribution.
 
-## Getting Started
+> **Security vulnerability?** Do **not** open an issue. Follow the process in [SECURITY.md](SECURITY.md) instead.
+
+---
+
+## Table of contents
+
+- [Getting started](#getting-started)
+- [Project structure](#project-structure)
+- [Architecture notes](#architecture-notes)
+- [What to contribute](#what-to-contribute)
+- [Making changes](#making-changes)
+- [Pull request format](#pull-request-format)
+- [Security requirements for contributors](#security-requirements-for-contributors)
+- [Code style](#code-style)
+- [Commit messages](#commit-messages)
+- [Questions?](#questions)
+
+---
+
+## Getting started
+
+### Prerequisites
+
+- Node.js 18+
+- A Chromium-based browser (Chrome, Edge, Brave) — required for the File System Access API
+
+### Setup
 
 ```bash
 git clone https://github.com/Nathanf22/BlueLens.git
@@ -11,92 +37,185 @@ npm install
 npm run dev        # http://localhost:3000
 ```
 
-### Prerequisites
+### AI features (optional)
 
-- Node.js 18+
-- A Chromium-based browser (required for File System Access API)
+AI-powered features require an API key. Copy `.env.example` to `.env` and fill it in:
 
-### AI Features (optional)
+```bash
+cp .env.example .env
+# Edit .env and add your GEMINI_API_KEY
+```
 
-AI-powered features (chat, code scanning, flow generation, smart grouping) require an API key from one of:
+Or configure it directly in the **AI Settings** panel inside the app. Supported providers:
 
-- Google Gemini
-- OpenAI
-- Anthropic (requires a CORS proxy)
+| Provider | Where to get a key |
+|----------|--------------------|
+| Google Gemini | [Google AI Studio](https://aistudio.google.com/) |
+| OpenAI | [OpenAI Platform](https://platform.openai.com/) |
+| Anthropic | API key + CORS proxy (browser restriction) |
 
-Copy `.env.example` to `.env` and add your key, or configure via the AI Settings panel in the app.
+---
 
-## Project Structure
+## Project structure
 
 ```
 BlueLens/
-  App.tsx                  # Root orchestrator — composes hooks, passes props
+  App.tsx                  # Root orchestrator — composes hooks, passes props down
   types.ts                 # All TypeScript types and interfaces
-  components/              # React components (no state — props only)
+  constants.ts             # App-wide constants
+  components/              # React components (stateless — props only)
   hooks/                   # Custom hooks (state + logic)
   services/                # Pure services (no React dependency)
+  public/                  # Static assets served by Vite
 ```
 
 There is no `src/` directory — source files live at the project root. The path alias `@/*` maps to the root.
 
-## Architecture Notes
+---
 
-- **No state library** — state is managed via custom hooks in `hooks/`, composed in `App.tsx`, and drilled via props.
+## Architecture notes
+
+- **No state library** — state lives in custom hooks in `hooks/`, composed in `App.tsx`, and passed via props.
 - **No backend** — everything runs client-side. Data persists to `localStorage` and `IndexedDB`.
-- **No test runner or linter** — contributions should build cleanly with `npm run build`.
+- **No test runner or linter** — contributions must build cleanly with `npm run build`.
+- **Props-only components** — components receive data via props and emit events via callbacks. No context providers.
 
-## Making Changes
+---
 
-1. Fork the repo and create a branch from `main`:
+## What to contribute
+
+Check the [PRD](PRD) and [PROGRESS.md](PROGRESS.md) for the full roadmap. Areas where contributions are most welcome:
+
+| Area | Details |
+|------|---------|
+| **Phase 4 — Collaboration** | Real-time editing with Yjs/CRDT, presence cursors, comment threads, permissions |
+| **Phase 5 — Polish** | Semantic search, version history, diagram templates, PDF/HTML export |
+| **Bug fixes** | Anything listed in [KNOWN_ISSUES.md](KNOWN_ISSUES.md) or reproducible bugs |
+| **Performance** | Force graph rendering, Mermaid re-render cycles |
+| **Tests** | No test framework exists yet — adding one with initial coverage is valuable |
+| **Documentation** | Improving this file, README, or inline code documentation |
+
+If you are not sure whether your idea fits the project, open an issue first to discuss it before writing code.
+
+---
+
+## Making changes
+
+1. **Fork** the repository and clone your fork:
    ```bash
-   git checkout -b feature/your-feature
+   git clone https://github.com/your-username/BlueLens.git
+   cd BlueLens
    ```
 
-2. Make your changes. Keep them focused — one feature or fix per PR.
+2. **Create a branch** from `main` with a descriptive name:
+   ```bash
+   git checkout -b feat/diagram-png-export
+   git checkout -b fix/crash-on-workspace-delete
+   ```
 
-3. Verify the build:
+3. **Make your changes.** Keep them focused — one feature or fix per PR.
+
+4. **Verify the build** before opening a PR:
    ```bash
    npm run build
    ```
 
-4. Commit with a clear message:
-   ```
-   feat: Add diagram export to PNG
-   fix: Prevent crash when deleting active workspace
-   ```
+5. **Run a security self-review** (see [Security requirements](#security-requirements-for-contributors) below).
 
-5. Open a Pull Request against `main`.
+6. **Commit** with a clear message following [Conventional Commits](#commit-messages).
 
-## What to Contribute
+7. **Push** your branch and open a Pull Request against `main`.
 
-Check the [PRD](PRD) and [PROGRESS.md](PROGRESS.md) for the roadmap. Some areas where help is welcome:
+---
 
-- **Phase 4 — Collaboration**: Real-time editing with Yjs/CRDT
-- **Phase 5 — Polish**: Semantic search, version history, templates, PDF export
-- **Bug fixes**: Anything that doesn't work as expected
-- **Performance**: The force graph and Mermaid rendering can always be faster
-- **Tests**: There are none yet — adding a test framework and initial coverage would be valuable
+## Pull request format
 
-## Code Style
+Every PR must use the [PR template](.github/PULL_REQUEST_TEMPLATE.md) provided. It will be loaded automatically when you open a PR on GitHub.
 
-- Follow existing patterns in the codebase
+A good PR includes:
+
+- **A clear description** of what changed and why
+- **A link to the related issue** (if one exists) using `Closes #123`
+- **Step-by-step testing instructions** so the reviewer can verify the change
+- **A completed security checklist** (see the template)
+- **Screenshots or a recording** for any UI changes
+- **One concern per PR** — avoid bundling unrelated changes
+
+PRs that are missing the security checklist or cannot be built with `npm run build` will be closed without review.
+
+---
+
+## Security requirements for contributors
+
+All contributions must meet these requirements before being merged.
+
+### Never commit secrets
+
+- Never hardcode API keys, tokens, passwords, or any credentials in source code
+- Never commit `.env` — it is in `.gitignore` for a reason
+- Use `.env.example` to document required environment variables (with placeholder values only)
+- If you accidentally commit a secret, rotate it immediately and notify the maintainer
+
+### Dependency safety
+
+- Justify any new dependency in your PR description
+- Run `npm audit` before opening a PR and resolve any high or critical findings:
+  ```bash
+  npm audit
+  npm audit fix   # for auto-fixable issues
+  ```
+- Prefer well-maintained packages with a history of security patches
+
+### XSS and injection prevention
+
+- Never pass untrusted user input to `dangerouslySetInnerHTML`, `eval()`, `Function()`, or `innerHTML`
+- The existing `dangerouslySetInnerHTML` uses in `Preview.tsx` and `CodeGraphVisualizer.tsx` are intentional — they only render SVG output from the Mermaid.js library, never from user input or external APIs. New uses of this pattern require explicit justification in the PR
+- Sanitize or validate all data that crosses a trust boundary (user input, external API responses, imported files)
+
+### localStorage and IndexedDB
+
+- Do not store sensitive data (API keys, tokens) in `localStorage` in plaintext
+- API keys entered in the AI Settings panel are already encrypted via AES-GCM before being written to IndexedDB — follow this pattern for any new credential storage
+
+### Reporting a vulnerability found during contribution
+
+If you discover a security vulnerability while working on a contribution, do not include a fix in your PR without first notifying the maintainer privately. Follow the process in [SECURITY.md](SECURITY.md).
+
+---
+
+## Code style
+
+- Follow existing patterns in the codebase — consistency matters more than personal preference
 - Prefer editing existing files over creating new ones
 - Keep components stateless — logic belongs in hooks or services
-- TypeScript strict mode — no `any` unless unavoidable
+- TypeScript strict mode — avoid `any`; use `unknown` + type narrowing when the type is truly uncertain
+- No comments for self-evident code; comments are for non-obvious decisions or trade-offs
 
-## Commit Messages
+---
+
+## Commit messages
 
 Use [Conventional Commits](https://www.conventionalcommits.org/):
 
-- `feat:` — new feature
-- `fix:` — bug fix
-- `refactor:` — code restructuring (no behavior change)
-- `docs:` — documentation only
-- `chore:` — build, deps, config
+| Prefix | Use for |
+|--------|---------|
+| `feat:` | New feature |
+| `fix:` | Bug fix |
+| `refactor:` | Code restructuring with no behavior change |
+| `docs:` | Documentation only |
+| `chore:` | Build, deps, config |
+| `perf:` | Performance improvement |
+| `security:` | Security fix (non-vulnerability — for vulnerability fixes, follow SECURITY.md) |
 
-## Security
+Examples:
+```
+feat: add PNG export for diagrams
+fix: prevent crash when deleting the active workspace
+docs: clarify File System Access API browser requirement
+security: redact API key from error log messages
+```
 
-Please read [SECURITY.md](SECURITY.md) before reporting vulnerabilities. Do **not** open public issues for security bugs.
+---
 
 ## Questions?
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,9 @@
 
 **Do not open a public GitHub issue for security vulnerabilities.**
 
-Please report security issues by emailing the maintainer directly:
+Public issues are visible to everyone, including potential attackers. Please report security issues by contacting the maintainer privately:
 
-**Nathan Kamokoue** — contact via [LinkedIn](https://www.linkedin.com/in/nathan-kamokoue-1289121b8/)
+**Nathan Kamokoue** — [LinkedIn](https://www.linkedin.com/in/nathan-kamokoue-1289121b8/)
 
 Include in your report:
 - A clear description of the vulnerability
@@ -14,48 +14,85 @@ Include in your report:
 - The potential impact
 - Any suggested fix (optional)
 
-You can expect an acknowledgement within 48 hours and a resolution timeline within the week for confirmed issues.
+You will receive an acknowledgement within 48 hours and a resolution timeline within the week for confirmed issues. We follow responsible disclosure — we will credit you in the fix unless you prefer to remain anonymous.
 
 ---
 
-## Security Considerations for Contributors and Users
+## Security Requirements for Contributors
+
+All contributions must pass the checklist in the [PR template](.github/PULL_REQUEST_TEMPLATE.md). Key requirements:
+
+### No secrets in code or commits
+
+- Never hardcode API keys, tokens, or passwords
+- Never commit `.env` (it is in `.gitignore`)
+- Use `.env.example` with placeholder values only
+- If you accidentally commit a secret, **rotate it immediately** before doing anything else, then notify the maintainer
+
+### Dependency hygiene
+
+- Justify new dependencies in your PR description
+- Run `npm audit` before opening a PR; resolve all high and critical findings
+- Avoid packages with no recent maintenance or known unpatched CVEs
+
+### XSS and injection
+
+- Never pass untrusted input to `dangerouslySetInnerHTML`, `eval()`, `Function()`, or `innerHTML`
+- Sanitize data at trust boundaries: user input, external API responses, imported files
+- New uses of `dangerouslySetInnerHTML` require explicit justification
+
+### Credential storage
+
+- Never write API keys or tokens to `localStorage` in plaintext
+- Follow the existing AES-GCM + IndexedDB encryption pattern for any new credential storage
+
+### Vulnerability found during contribution
+
+If you find a security vulnerability while working on a feature or bug fix, **do not include a fix in your PR**. Report it privately first so a coordinated fix can be prepared.
+
+---
+
+## Security Considerations for Users and Self-Hosters
 
 ### API Keys
 
-BlueLens supports multiple LLM providers (Gemini, OpenAI, Anthropic). API keys are handled in two ways depending on context:
+BlueLens supports multiple LLM providers. API keys are handled differently depending on how you configure them:
 
-| Context | Storage | Risk |
-|---------|---------|------|
-| In-app AI Settings | Encrypted via AES-GCM + IndexedDB | Keys never leave the browser |
-| `.env` file (dev/self-host) | Local file, bundled by Vite at build time | **Baked into the production bundle** |
+| Method | Storage | Risk |
+|--------|---------|------|
+| In-app AI Settings panel | Encrypted via AES-GCM, stored in IndexedDB | Keys never leave the browser in plaintext |
+| `.env` file (dev / self-host) | Bundled into JS at build time by Vite | **Baked into the production bundle — visible in source** |
 
-**Critical:** If you use a `.env` file with `GEMINI_API_KEY`, that key will be inlined into the JavaScript bundle at build time. **Never deploy a production build built with a real API key in `.env`.** Use the in-app AI Settings panel instead — keys stored there are encrypted and never bundled.
+**Critical for self-hosters:** If you place a real API key in `.env` and run `npm run build`, that key will be inlined into the JavaScript bundle. Anyone who can access your deployed app can extract it. Use the in-app AI Settings panel instead for any deployment.
 
-The `.env` file is listed in `.gitignore`. Never commit it.
+### `dangerouslySetInnerHTML`
 
-### `dangerouslySetInnerHTML` Usage
+BlueLens uses `dangerouslySetInnerHTML` in two places:
 
-BlueLens renders Mermaid diagrams using `dangerouslySetInnerHTML` in `components/Preview.tsx` and `components/CodeGraphVisualizer.tsx`. The SVG content in both cases is produced by the Mermaid.js library from the user's own diagram code — it is never derived from untrusted external input. This is an accepted pattern for Mermaid rendering.
+- `components/Preview.tsx` — renders SVG produced by Mermaid.js from the user's own diagram code
+- `components/CodeGraphVisualizer.tsx` — renders sequence diagram SVG produced by Mermaid.js
 
-### localStorage / IndexedDB
+In both cases the content comes from Mermaid's renderer, not from user-controlled strings or external APIs. This is the standard pattern for embedding Mermaid output in React.
 
-All user data (diagrams, workspaces, comments, node links) is stored locally in the browser. No data is sent to any server. The exception is AI features, which send diagram content or code snippets to the configured LLM provider API.
+### localStorage and IndexedDB
+
+All user data (diagrams, workspaces, comments, node links) is stored locally in your browser. Nothing is sent to any server, except the content you choose to send to an LLM provider (diagram code, code snippets) when using AI features.
 
 ### File System Access API
 
-Code Integration features use the browser's File System Access API to read local files. The app requests read-only access to the directories you select. No file writes are performed outside of what the browser sandbox permits.
+Code integration features use the browser's File System Access API to read local files. The app requests read-only access to the directories you select. No writes are made to your filesystem.
 
-### Content Security Policy
+### CDN Dependencies
 
-BlueLens currently loads dependencies from CDNs (`cdn.tailwindcss.com`, `esm.sh`, `fonts.googleapis.com`). A strict CSP is not enforced at this time. For self-hosted deployments in sensitive environments, consider proxying these resources locally.
+BlueLens loads some dependencies from CDNs at runtime (`cdn.tailwindcss.com`, `esm.sh`, `fonts.googleapis.com`). A strict Content Security Policy is not enforced. For deployments in security-sensitive environments, consider self-hosting these resources.
 
 ---
 
 ## Supported Versions
 
-This project is in active development. Security fixes are applied to the `main` branch only.
+Security fixes are applied to the `main` branch only.
 
 | Version | Supported |
 |---------|-----------|
 | `main` | Yes |
-| Older tags | No |
+| Older releases | No |


### PR DESCRIPTION
## Description

Complète la documentation open source de BlueLens avec des templates GitHub et des guidelines détaillées.

## Type of change

- [x] Documentation only

## Changes

### `.github/PULL_REQUEST_TEMPLATE.md`
Template automatiquement chargé à chaque nouvelle PR avec :
- Description + lien vers l'issue
- Type de changement
- Instructions de test
- **Security checklist** (secrets, XSS, dépendances, `dangerouslySetInnerHTML`)
- Screenshots / notes pour les reviewers

### `.github/ISSUE_TEMPLATE/`
- `bug_report.md` — template structuré pour les rapports de bug
- `feature_request.md` — template pour les demandes de fonctionnalité, lié au roadmap
- `security_report.md` — redirige les reporters de vulnérabilités vers SECURITY.md (évite les issues publiques)

### `CONTRIBUTING.md` (réécriture)
- Table des matières complète
- Section **Pull request format** : ce qu'attend chaque PR
- Section **Security requirements for contributors** : secrets, dépendances, XSS, stockage de credentials, que faire si une vuln est trouvée en cours de contribution
- Tableau des types de contributions avec les phases du roadmap

### `SECURITY.md` (mise à jour)
- Nouvelle section **Security Requirements for Contributors** en tête de fichier
- Règles concrètes : pas de secrets, `npm audit`, XSS, stockage chiffré
- Processus en cas de vuln trouvée pendant une contribution

## Security checklist

- [x] No API keys, tokens, or secrets hardcoded
- [x] No new `dangerouslySetInnerHTML` usage
- [x] No new dependencies
- [x] Documentation only — no code changes