### PR TITLE
chore: remove Phase 4 Collaboration (cloud-only)

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -22,8 +22,7 @@ assignees: ""
 
 <!-- Check the phase this relates to, if any. See PRD or README for the full roadmap. -->
 
-- [ ] Phase 4 — Collaboration (Yjs/CRDT, presence, permissions)
-- [ ] Phase 5 — Polish (search, version history, templates, exports)
+- [ ] Phase 4 — Polish (search, version history, templates, exports)
 - [ ] Other / not on the roadmap
 
 ## Additional context

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,8 +79,7 @@ Blueprint aims to be a living architecture diagram platform that syncs with code
 - **Phase 1 — Foundation (MVP):** COMPLETE. Mermaid editor with live preview, multi-level zoom navigation with badges, breadcrumb navigation, workspace/folder management, import/export.
 - **Phase 2 — Code Integration:** UP NEXT. File System Access API, Tree-sitter WASM parsing (Python, TS/JS), manual code linking, Monaco Editor for code viewing, split diagram+code view, multi-repo support.
 - **Phase 3 — Intelligence Layer:** On-demand code scanning, divergence detection, AI chat panel for diagram modifications, visual diff, three sync modes (manual/semi-auto/auto).
-- **Phase 4 — Collaboration:** Yjs CRDT real-time editing, WebSocket server, presence/cursors, element-specific comment threads, permissions, offline-first sync.
-- **Phase 5 — Polish & Advanced:** Semantic search, auto-tagging, version history, diagram templates, advanced exports (PDF/HTML with comments).
+- **Phase 4 — Polish & Advanced:** Semantic search, auto-tagging, version history, diagram templates, advanced exports (PDF/HTML with comments).
 
 ## Git Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,8 +88,7 @@ Check the [PRD](PRD) and [PROGRESS.md](PROGRESS.md) for the full roadmap. Areas 
 
 | Area | Details |
 |------|---------|
-| **Phase 4 — Collaboration** | Real-time editing with Yjs/CRDT, presence cursors, comment threads, permissions |
-| **Phase 5 — Polish** | Semantic search, version history, diagram templates, PDF/HTML export |
+| **Phase 4 — Polish** | Semantic search, version history, diagram templates, PDF/HTML export |
 | **Bug fixes** | Anything listed in [KNOWN_ISSUES.md](KNOWN_ISSUES.md) or reproducible bugs |
 | **Performance** | Force graph rendering, Mermaid re-render cycles |
 | **Tests** | No test framework exists yet — adding one with initial coverage is valuable |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -84,15 +84,7 @@ PRD specifies encrypted IndexedDB storage. Currently API keys are stored in plai
 ### Dead Code
 - `services/geminiService.ts` still exists but is no longer imported by any code (replaced by `llmService`). Can be deleted.
 
-## Phase 4: Collaboration — NOT STARTED
-- Yjs CRDT real-time editing
-- WebSocket server
-- Presence/cursors
-- Element-specific comment threads
-- Permissions
-- Offline-first sync
-
-## Phase 5: Polish & Advanced — NOT STARTED
+## Phase 4: Polish & Advanced — NOT STARTED
 - Semantic search
 - Auto-tagging
 - Version history


### PR DESCRIPTION
Phase 4 Collaboration (Yjs/CRDT, WebSocket, présence, permissions) est réservée à BlueLens Cloud. Retirée de tous les docs et templates open source. Phase 5 Polish renommée en Phase 4.