### PR TITLE
docs: add GitHub Discussions links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ Check the [PRD](PRD) and [PROGRESS.md](PROGRESS.md) for the full roadmap. Areas 
 | **Tests** | No test framework exists yet — adding one with initial coverage is valuable |
 | **Documentation** | Improving this file, README, or inline code documentation |
 
-If you are not sure whether your idea fits the project, open an issue first to discuss it before writing code.
+If you are not sure whether your idea fits the project, start a [Discussion](https://github.com/Nathanf22/BlueLens/discussions) before opening an issue or writing code.
 
 ---
 
@@ -218,6 +218,12 @@ security: redact API key from error log messages
 
 ## Questions?
 
-Open an issue on GitHub or reach out to the maintainer:
+| Channel | Use for |
+|---------|---------|
+| [Discussions](https://github.com/Nathanf22/BlueLens/discussions/categories/q-a) | Usage questions, setup help, general support |
+| [Ideas](https://github.com/Nathanf22/BlueLens/discussions/categories/ideas) | Feature brainstorming before opening a formal issue |
+| [Issues](https://github.com/Nathanf22/BlueLens/issues) | Confirmed bugs and well-defined feature requests |
+
+Or reach out to the maintainer directly:
 
 **Nathan Kamokoue** — [LinkedIn](https://www.linkedin.com/in/nathan-kamokoue-1289121b8/) / [X](https://x.com/KamokoueNathan)

--- a/README.md
+++ b/README.md
@@ -161,6 +161,11 @@ BlueLens/
 
 ---
 
+## Community
+
+- [Discussions](https://github.com/Nathanf22/BlueLens/discussions) — questions, ideas, show and tell
+- [Issues](https://github.com/Nathanf22/BlueLens/issues) — bugs and feature requests
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions, architecture notes, and guidelines.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,9 @@
 
 ## Reporting a Vulnerability
 
-**Do not open a public GitHub issue for security vulnerabilities.**
+**Do not open a public GitHub issue or Discussion for security vulnerabilities.**
 
-Public issues are visible to everyone, including potential attackers. Please report security issues by contacting the maintainer privately:
+Public issues and Discussions are visible to everyone, including potential attackers. Please report security issues by contacting the maintainer privately:
 
 **Nathan Kamokoue** — [LinkedIn](https://www.linkedin.com/in/nathan-kamokoue-1289121b8/)
 


### PR DESCRIPTION
## Summary

- **README.md** — add Community section linking to Discussions and Issues
- **CONTRIBUTING.md** — point vague questions to Discussions instead of Issues; replace the Q&A footer with a channel table (Discussions / Ideas / Issues)
- **SECURITY.md** — clarify that public Discussions are also not the right place to report vulnerabilities

## Test plan

- [ ] All links resolve correctly on GitHub