### PR TITLE
fix: resolve repo UUID mismatch on re-add (KI-001) + clean up RepoManager

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -632,7 +632,6 @@ export default function App() {
         codebaseImportProgress={codebaseImportProgress}
         isCodebaseImporting={isCodebaseImporting}
         onResetCodebaseImport={resetCodebaseImport}
-        onOpenCodebaseImport={() => setIsCodebaseImportOpen(true)}
         onCreateGraph={handleCreateGraph}
         isCodeGraphConfigOpen={isCodeGraphConfigOpen}
         onCloseCodeGraphConfig={() => setIsCodeGraphConfigOpen(false)}

--- a/components/ModalManager.tsx
+++ b/components/ModalManager.tsx
@@ -69,8 +69,6 @@ interface ModalManagerProps {
   codebaseImportProgress: CodebaseImportProgress | null;
   isCodebaseImporting: boolean;
   onResetCodebaseImport: () => void;
-  // Generate Diagrams trigger from RepoManager
-  onOpenCodebaseImport: () => void;
   // Create Code Graph trigger from RepoManager
   onCreateGraph?: (repoId: string) => Promise<any>;
   // CodeGraph Config
@@ -133,7 +131,6 @@ export const ModalManager: React.FC<ModalManagerProps> = ({
   codebaseImportProgress,
   isCodebaseImporting,
   onResetCodebaseImport,
-  onOpenCodebaseImport,
   onCreateGraph,
   isCodeGraphConfigOpen,
   onCloseCodeGraphConfig,
@@ -171,7 +168,6 @@ export const ModalManager: React.FC<ModalManagerProps> = ({
           onRemoveRepo={onRemoveRepo}
           onReopenRepo={onReopenRepo}
           onClose={onCloseRepoManager}
-          onGenerateDiagrams={onOpenCodebaseImport}
           onCreateGraph={onCreateGraph}
         />
       )}


### PR DESCRIPTION
## Closes

- Closes #6 (KI-001 — View Code breaks when repo is removed and re-added)
- Partially closes #4 (removes Generate Diagrams button from RepoManager, which was part of the SCAN feature)

## Root cause (#6)

When a repo was removed, `fileSystemService.removeHandle()` deleted the entry from both the in-memory store and IndexedDB. On re-add, `handleAddRepo` generated a fresh UUID — leaving all existing CodeGraph nodes and diagram codeLinks referencing a stale ID with no handle.

## Fix

- `removeHandle` no longer deletes from IndexedDB (handle is preserved for re-add detection)
- Two new methods on `fileSystemService`: `getAllPersistedIds()` and `findPersistedIdForDirectory()` — uses the browser's `isSameEntry()` API to accurately detect when the user re-adds the same directory
- `handleAddRepo` reuses the original repo ID when `isSameEntry()` matches, so all CodeGraph and codeLink references remain valid
- Toast feedback ("Reconnected to [name]") on re-add

## RepoManager cleanup

- Removed **Generate Diagrams** button (SCAN feature, superseded by CodeGraph)
- Added `isCreatingGraph` loading state to the **Create Code Graph** button — consistent with the same button in `Sidebar.tsx`
- Removed `onGenerateDiagrams` prop and `onOpenCodebaseImport` wiring from `ModalManager` and `App.tsx`

## Test plan

- [ ] Add a repo, build a CodeGraph, remove the repo, re-add the same directory → View Code on a CodeGraph node works without error
- [ ] Re-adding a repo shows "Reconnected to [name]" toast instead of adding a duplicate entry
- [ ] Create Code Graph button in RepoManager shows spinner and disables during creation
- [ ] Generate Diagrams button is no longer visible in RepoManager