### PR TITLE
feat: improve CodeGraph/diagram navigation and preview background

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -322,6 +322,18 @@ export default function App() {
     codeGraph.analyzeDomain(llmSettings);
   }, [codeGraph.analyzeDomain, llmSettings]);
 
+  const handleOpenFlowInEditor = useCallback((flow: import('./types').GraphFlow) => {
+    const existing = diagrams.find(
+      d => d.sourceGraphId === codeGraph.activeGraphId && d.name === flow.name
+    );
+    if (existing) {
+      setActiveId(existing.id);
+      codeGraph.selectGraph(null);
+    } else {
+      showToast('Flow not yet exported. Use "Export Flows" to create the diagram first.', 'info');
+    }
+  }, [diagrams, codeGraph.activeGraphId, codeGraph.selectGraph, setActiveId, showToast]);
+
   // --- Diagram Analysis ---
   const [diagramAnalysis, setDiagramAnalysis] = useState<DiagramAnalysis | null>(null);
 
@@ -468,7 +480,10 @@ export default function App() {
             workspaces={workspaces}
             activeWorkspaceId={activeWorkspaceId}
             activeId={activeId}
-            onSelect={setActiveId}
+            onSelect={(id) => {
+              setActiveId(id);
+              if (codeGraph.activeGraphId) codeGraph.selectGraph(null);
+            }}
             onCreate={handleCreateDiagram}
             onDelete={handleDeleteDiagram}
             onImport={handleImportDiagrams}
@@ -569,6 +584,7 @@ export default function App() {
           codeGraphActiveFlowId={codeGraph.activeFlowId}
           onCodeGraphSelectFlow={codeGraph.selectFlow}
           onCodeGraphDeselectFlow={codeGraph.deselectFlow}
+          onCodeGraphOpenFlowInEditor={handleOpenFlowInEditor}
           codeGraphIsGeneratingFlows={codeGraph.isGeneratingFlows}
           onCodeGraphRegenerateFlows={handleRegenerateFlows}
           progressLogEntries={progressLog.entries}

--- a/components/CodeGraphVisualizer.tsx
+++ b/components/CodeGraphVisualizer.tsx
@@ -7,7 +7,7 @@
 import React, { useEffect, useRef, useMemo, useCallback, useState } from 'react';
 import * as d3 from 'd3';
 import { createRoot } from 'react-dom/client';
-import { ZoomIn, ZoomOut, Eye, Server, Box, Network, FileText, Terminal, Cpu, ShieldCheck, Layers, Code2 } from 'lucide-react';
+import { ZoomIn, ZoomOut, Eye, Server, Box, Network, FileText, Terminal, Cpu, ShieldCheck, Layers, Code2, ExternalLink } from 'lucide-react';
 import mermaid from 'mermaid';
 import { CodeGraph, ViewLens, GraphNodeKind, RelationType, GraphFlow } from '../types';
 import { codeGraphModelService } from '../services/codeGraphModelService';
@@ -62,6 +62,7 @@ interface CodeGraphVisualizerProps {
   onNodeClick: (nodeId: string) => void;
   onNodeDoubleClick: (nodeId: string) => void;
   onBackgroundClick: () => void;
+  onOpenInEditor?: (flow: GraphFlow) => void;
 }
 
 export const CodeGraphVisualizer: React.FC<CodeGraphVisualizerProps> = ({
@@ -73,6 +74,7 @@ export const CodeGraphVisualizer: React.FC<CodeGraphVisualizerProps> = ({
   onNodeClick,
   onNodeDoubleClick,
   onBackgroundClick,
+  onOpenInEditor,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const svgRef = useRef<SVGSVGElement>(null);
@@ -376,6 +378,16 @@ export const CodeGraphVisualizer: React.FC<CodeGraphVisualizerProps> = ({
             <p className="text-[10px] text-gray-500 truncate">{activeFlow.description}</p>
           </div>
           <span className="text-[10px] text-gray-600 flex-shrink-0">{activeFlow.steps.length} steps</span>
+          {onOpenInEditor && activeFlow.sequenceDiagram && (
+            <button
+              onClick={() => onOpenInEditor(activeFlow)}
+              className="flex items-center gap-1 px-2 py-1 rounded text-[10px] text-gray-400 hover:text-cyan-400 hover:bg-gray-800 transition-colors flex-shrink-0"
+              title="Open in diagram editor"
+            >
+              <ExternalLink size={11} />
+              Open in editor
+            </button>
+          )}
         </div>
         <div className="flex-1 overflow-auto p-4 flex items-start justify-center">
           {seqSvg

--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -46,7 +46,7 @@ export const Editor: React.FC<EditorProps> = ({ code, name, onCodeChange, onName
   const lineNumbers = Array.from({ length: lineCount }, (_, i) => i + 1);
 
   return (
-    <div className={`flex flex-col h-full bg-dark-900 border-r border-gray-700 transition-all duration-300 ease-in-out ${isCollapsed ? 'w-12' : 'flex-1'}`}>
+    <div className={`flex flex-col h-full bg-black border-r border-gray-700 transition-all duration-300 ease-in-out ${isCollapsed ? 'w-12' : 'flex-1'}`}>
       {isCollapsed ? (
         // Collapsed view - vertical tab
         <div className="flex flex-col items-center justify-center h-full gap-4 py-8">
@@ -75,7 +75,7 @@ export const Editor: React.FC<EditorProps> = ({ code, name, onCodeChange, onName
             type="text" 
             value={name}
             onChange={(e) => onNameChange(e.target.value)}
-            className="bg-transparent border-none outline-none text-sm font-medium text-gray-300 focus:text-white placeholder-gray-600 w-full hover:bg-dark-900/50 rounded px-1 -ml-1 transition-colors"
+            className="bg-transparent border-none outline-none text-sm font-medium text-gray-300 focus:text-white placeholder-gray-600 w-full hover:bg-black/50 rounded px-1 -ml-1 transition-colors"
             placeholder="Diagram Name"
           />
         </div>
@@ -83,7 +83,7 @@ export const Editor: React.FC<EditorProps> = ({ code, name, onCodeChange, onName
         <div className="flex items-center gap-3 shrink-0">
           <button
             onClick={onToggleCollapse}
-            className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-gray-400 hover:text-brand-400 bg-dark-900 hover:bg-dark-700 border border-gray-700 hover:border-brand-500/50 rounded transition-all"
+            className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-gray-400 hover:text-brand-400 bg-black hover:bg-dark-700 border border-gray-700 hover:border-brand-500/50 rounded transition-all"
             title="Collapse editor"
           >
             <ChevronLeft className="w-3.5 h-3.5" />
@@ -113,7 +113,7 @@ export const Editor: React.FC<EditorProps> = ({ code, name, onCodeChange, onName
         {/* Line Numbers Column */}
         <div 
           ref={lineNumbersRef}
-          className="hidden sm:block flex-shrink-0 w-12 bg-dark-900 border-r border-gray-800 text-right text-gray-600 font-mono text-sm leading-6 py-4 pr-3 select-none overflow-hidden"
+          className="hidden sm:block flex-shrink-0 w-12 bg-black border-r border-gray-800 text-right text-gray-600 font-mono text-sm leading-6 py-4 pr-3 select-none overflow-hidden"
           style={{ fontFamily: "'JetBrains Mono', monospace" }}
           aria-hidden="true"
         >
@@ -128,7 +128,7 @@ export const Editor: React.FC<EditorProps> = ({ code, name, onCodeChange, onName
           value={code}
           onChange={(e) => onCodeChange(e.target.value)}
           onScroll={handleScroll}
-          className="flex-1 w-full h-full py-4 pl-3 pr-4 bg-dark-900 text-gray-300 font-mono text-sm leading-6 resize-none outline-none border-none focus:ring-0 whitespace-pre overflow-auto"
+          className="flex-1 w-full h-full py-4 pl-3 pr-4 bg-black text-gray-300 font-mono text-sm leading-6 resize-none outline-none border-none focus:ring-0 whitespace-pre overflow-auto"
           spellCheck={false}
           style={{ fontFamily: "'JetBrains Mono', monospace" }}
           placeholder="Enter Mermaid code here..."

--- a/components/Preview.tsx
+++ b/components/Preview.tsx
@@ -245,7 +245,7 @@ export const Preview: React.FC<PreviewProps> = ({
   };
 
   return (
-    <div ref={outerRef} className="relative w-full h-full bg-dark-800 overflow-hidden flex flex-col rounded-lg border border-gray-700 group">
+    <div ref={outerRef} className="relative w-full h-full bg-black overflow-hidden flex flex-col rounded-lg border border-gray-700 group">
       
       {/* Breadcrumb Navigation */}
       {breadcrumbPath.length > 0 && (

--- a/components/WorkspaceView.tsx
+++ b/components/WorkspaceView.tsx
@@ -80,6 +80,7 @@ interface WorkspaceViewProps {
   codeGraphActiveFlowId?: string | null;
   onCodeGraphSelectFlow?: (flowId: string) => void;
   onCodeGraphDeselectFlow?: () => void;
+  onCodeGraphOpenFlowInEditor?: (flow: GraphFlow) => void;
   // CodeGraph flow generation
   codeGraphIsGeneratingFlows?: boolean;
   onCodeGraphRegenerateFlows?: (options?: { scopeNodeId?: string; customPrompt?: string }) => void;
@@ -160,6 +161,7 @@ export const WorkspaceView: React.FC<WorkspaceViewProps> = ({
   codeGraphActiveFlowId = null,
   onCodeGraphSelectFlow,
   onCodeGraphDeselectFlow,
+  onCodeGraphOpenFlowInEditor,
   codeGraphIsGeneratingFlows = false,
   onCodeGraphRegenerateFlows,
   progressLogEntries = [],
@@ -277,6 +279,7 @@ export const WorkspaceView: React.FC<WorkspaceViewProps> = ({
                 onNodeClick={onCodeGraphSelectNode || (() => {})}
                 onNodeDoubleClick={onCodeGraphFocusNode || (() => {})}
                 onBackgroundClick={onCodeGraphDeselectNode || (() => {})}
+                onOpenInEditor={onCodeGraphOpenFlowInEditor}
               />
             </div>
           ) : (


### PR DESCRIPTION
## Summary

- Selecting a diagram in Sidebar while CodeGraph is open now closes CodeGraph and opens the selected diagram
- Add **"Open in editor"** button on flow sequence diagram view — navigates to the already-exported flow diagram (matched by `sourceGraphId` + flow name)
- Make diagram preview background black
- Make editor (textarea) background black

## Test plan

- [ ] Open a CodeGraph, then click a diagram in the Sidebar — CodeGraph should close and the diagram should open
- [ ] View a flow in CodeGraph, click "Open in editor" — should navigate to the matching exported diagram
- [ ] Verify diagram preview area background is now black
- [ ] Verify editor textarea background is now black

🤖 Generated with [Claude Code](https://claude.com/claude-code)