### PR TITLE
fix: resolve GitHub default branch + update RepoConfig for View Code

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -134,7 +134,7 @@ export default function App() {
   const { handleAddNodeLink, handleRemoveNodeLink } =
     useNodeLinkHandlers(activeDiagram, updateActiveDiagram);
 
-  const { handleAddRepo, handleAddGithubRepo, handleRemoveRepo, handleReopenRepo } =
+  const { handleAddRepo, handleAddGithubRepo, handleRemoveRepo, handleReopenRepo, handleUpdateGithubBranch } =
     useRepoHandlers(repos, setRepos, activeWorkspaceId, showToast);
 
   const { handleAddCodeLink, handleRemoveCodeLink } =
@@ -310,6 +310,7 @@ export default function App() {
           repo.githubBranch || 'main',
           llmSettings,
           progressLog.addEntry,
+          (resolvedBranch) => handleUpdateGithubBranch(repoId, resolvedBranch),
         );
       } else {
         result = await codeGraph.createGraph(repoId, llmSettings, progressLog.addEntry);
@@ -329,7 +330,7 @@ export default function App() {
       progressLog.endLog();
       setIsCreatingGraph(false);
     }
-  }, [workspaceRepos, codeGraph.createGraph, codeGraph.createGithubGraph, llmSettings, progressLog.startLog, progressLog.addEntry, progressLog.endLog, triggerFlowExport, showToast, setIsAISettingsOpen]);
+  }, [workspaceRepos, codeGraph.createGraph, codeGraph.createGithubGraph, llmSettings, progressLog.startLog, progressLog.addEntry, progressLog.endLog, triggerFlowExport, showToast, setIsAISettingsOpen, handleUpdateGithubBranch]);
 
   const handleCancelCreateGraph = useCallback(() => {
     graphCreationCancelledRef.current = true;

--- a/hooks/useCodeGraph.ts
+++ b/hooks/useCodeGraph.ts
@@ -209,6 +209,7 @@ export const useCodeGraph = (activeWorkspaceId: string) => {
     branch: string,
     llmSettings?: LLMSettings,
     onLogEntry?: LogEntryFn,
+    onBranchResolved?: (resolvedBranch: string) => void,
   ) => {
     const controller = new AbortController();
     abortControllerRef.current = controller;
@@ -225,6 +226,7 @@ export const useCodeGraph = (activeWorkspaceId: string) => {
         repoId,
         (step, current, total) => setGraphCreationProgress({ step, current, total }),
         onLogEntry,
+        onBranchResolved,
       );
       onLogEntry?.('scan', `Scan complete: ${analysis.totalFiles} files, ${analysis.totalSymbols} symbols`);
 

--- a/hooks/useRepoHandlers.ts
+++ b/hooks/useRepoHandlers.ts
@@ -111,10 +111,15 @@ export const useRepoHandlers = (
     );
   };
 
+  const handleUpdateGithubBranch = (repoId: string, branch: string) => {
+    setRepos(prev => prev.map(r => r.id === repoId ? { ...r, githubBranch: branch } : r));
+  };
+
   return {
     handleAddRepo,
     handleAddGithubRepo,
     handleRemoveRepo,
     handleReopenRepo,
+    handleUpdateGithubBranch,
   };
 };

--- a/services/githubDemoService.ts
+++ b/services/githubDemoService.ts
@@ -108,6 +108,7 @@ export async function fetchGithubAnalysis(
   repoId: string,
   onProgress?: DemoProgressCallback,
   onLogEntry?: LogEntryFn,
+  onBranchResolved?: (resolvedBranch: string) => void,
 ): Promise<CodebaseAnalysis> {
   // 1. Fetch file tree — if branch is not found (404), resolve the default branch and retry once
   onProgress?.('Fetching repository structure', 0, 1);
@@ -134,6 +135,7 @@ export async function fetchGithubAnalysis(
         if (repoData.default_branch && repoData.default_branch !== resolvedBranch) {
           resolvedBranch = repoData.default_branch;
           onLogEntry?.('scan', `Branch '${branch}' not found, retrying with '${resolvedBranch}'…`);
+          onBranchResolved?.(resolvedBranch);
           treeRes = await fetchTree(resolvedBranch);
         }
       }


### PR DESCRIPTION
## Problem

When adding a GitHub repo by URL without an explicit branch, the code defaults to `main`. If the repo's actual default branch is `master` (or anything else):

1. **Graph creation** failed with `HTTP 404 — Not Found` on the tree fetch
2. **View Code** failed with `Failed to fetch file from GitHub` even after the graph was created — because `RepoConfig.githubBranch` still stored the wrong branch guess

## Fix

**`githubDemoService.ts`** — on a 404 tree fetch, query `GET /repos/{owner}/{repo}` to get `default_branch` and retry once. An `onBranchResolved` callback is called when the branch is auto-corrected.

**`useCodeGraph.ts`** — `createGithubGraph` accepts and threads `onBranchResolved` through to `fetchGithubAnalysis`.

**`useRepoHandlers.ts`** — new `handleUpdateGithubBranch(repoId, branch)` updates the stored branch in state.

**`App.tsx`** — `handleCreateGraph` passes `(resolvedBranch) => handleUpdateGithubBranch(repoId, resolvedBranch)` so the `RepoConfig` is corrected in place once the real branch is known.

## Test plan

- [x] Add a GitHub repo that uses `master` as default branch (e.g. without `/tree/master` in the URL) — graph creation should succeed
- [x] Progress log should show `Branch 'main' not found, retrying with 'master'…`
- [x] After graph creation, "View Code" on a node should fetch the file correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)