### PR TITLE
fix: surface LLM quota and auth errors clearly to the user

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,7 +5,7 @@ import { AppFooter } from './components/AppFooter';
 import { WorkspaceView } from './components/WorkspaceView';
 import { ModalManager } from './components/ModalManager';
 import { BlueprintImportResult } from './services/exportService';
-import { llmService, LLMConfigError } from './services/llmService';
+import { llmService, LLMConfigError, LLMRateLimitError } from './services/llmService';
 import { aiChatService } from './services/aiChatService';
 import { fileSystemService } from './services/fileSystemService';
 import { DEMO_REPO_ID, DEMO_RAW_BASE, buildRawBase } from './services/githubDemoService';
@@ -319,7 +319,9 @@ export default function App() {
       else if (graphCreationCancelledRef.current) showToast('Graph creation cancelled', 'info');
       return result;
     } catch (err: any) {
-      if (err instanceof LLMConfigError) {
+      if (err instanceof LLMRateLimitError) {
+        showToast(err.message, 'error');
+      } else if (err instanceof LLMConfigError) {
         showToast('An AI API key is required to create a Code Graph. Configure one in AI Settings.', 'error');
         setIsAISettingsOpen(true);
       } else {
@@ -344,7 +346,9 @@ export default function App() {
         // Export only flows at the scope that was regenerated
         if (codeGraph.activeGraph) triggerFlowExport(codeGraph.activeGraph, options?.scopeNodeId);
       } catch (err: any) {
-        if (err instanceof LLMConfigError) {
+        if (err instanceof LLMRateLimitError) {
+          showToast(err.message, 'error');
+        } else if (err instanceof LLMConfigError) {
           showToast('An AI API key is required to generate sequence diagrams. Configure one in AI Settings.', 'error');
           setIsAISettingsOpen(true);
         } else {
@@ -638,7 +642,9 @@ export default function App() {
                 codeGraph.loadDemoGraph(llmSettings, progressLog.addEntry)
                   .then(graph => { if (graph) triggerFlowExport(graph); })
                   .catch((err: any) => {
-                    if (err instanceof LLMConfigError) {
+                    if (err instanceof LLMRateLimitError) {
+                      showToast(err.message, 'error');
+                    } else if (err instanceof LLMConfigError) {
                       showToast('An AI API key is required to load the demo graph. Configure one in AI Settings.', 'error');
                       setIsAISettingsOpen(true);
                     }

--- a/hooks/useCodeGraph.ts
+++ b/hooks/useCodeGraph.ts
@@ -16,7 +16,7 @@ import { groupByFunctionalHeuristics } from '../services/codeGraphHeuristicGroup
 import { generateFlows, type FlowGenerationResult, type FlowGenerationOptions } from '../services/codeGraphFlowService';
 import { fetchGithubAnalysis, DEMO_REPO_ID, DEMO_OWNER, DEMO_REPO, DEMO_BRANCH } from '../services/githubDemoService';
 import { fileSystemService } from '../services/fileSystemService';
-import { LLMConfigError } from '../services/llmService';
+import { LLMConfigError, LLMRateLimitError } from '../services/llmService';
 
 /** Throws LLMConfigError if no API key is configured for the active provider. */
 function requireLLMKey(llmSettings: LLMSettings | undefined): void {
@@ -396,8 +396,8 @@ export const useCodeGraph = (activeWorkspaceId: string) => {
     } catch (err: any) {
       if (err.name === 'AbortError') {
         onLogEntry?.('info', 'Demo graph load cancelled');
-      } else if (err instanceof LLMConfigError) {
-        throw err; // Let App.tsx handle opening AI Settings
+      } else if (err instanceof LLMConfigError || err instanceof LLMRateLimitError) {
+        throw err; // Let App.tsx handle
       } else {
         const message = err?.message ?? 'Failed to load demo graph';
         setDemoError(message);

--- a/services/codeGraphAgentService.ts
+++ b/services/codeGraphAgentService.ts
@@ -9,7 +9,7 @@
  */
 
 import { CodebaseAnalysis, CodebaseModule, AnalyzedFile, LLMSettings, ProgressLogCategory } from '../types';
-import { llmService } from './llmService';
+import { llmService, LLMConfigError, LLMRateLimitError } from './llmService';
 import { groupByFunctionalHeuristics } from './codeGraphHeuristicGrouper';
 
 export type LogEntryFn = (category: ProgressLogCategory, message: string, detail?: string) => void;
@@ -202,6 +202,7 @@ async function analyzeFilesBatch(
         return validated;
       }
     } catch (err) {
+      if (err instanceof LLMRateLimitError || err instanceof LLMConfigError) throw err;
       console.warn(`[CodeGraph Agent 1] Batch attempt ${attempt + 1} failed:`, err);
     }
   }
@@ -401,6 +402,7 @@ async function buildArchitecture(
         console.warn(`[CodeGraph Agent 2] Attempt ${attempt + 1}: validation failed`);
       }
     } catch (err) {
+      if (err instanceof LLMRateLimitError || err instanceof LLMConfigError) throw err;
       console.warn(`[CodeGraph Agent 2] Attempt ${attempt + 1} error:`, err);
     }
   }

--- a/services/codeGraphFlowService.ts
+++ b/services/codeGraphFlowService.ts
@@ -9,7 +9,7 @@
  */
 
 import { CodeGraph, GraphFlow, GraphFlowStep, GraphNode, LLMSettings } from '../types';
-import { llmService } from './llmService';
+import { llmService, LLMConfigError, LLMRateLimitError } from './llmService';
 import type { LogEntryFn } from './codeGraphAgentService';
 
 const generateId = () => Math.random().toString(36).substr(2, 9);
@@ -442,6 +442,7 @@ async function generateFlowsWithLLM(
 
       console.warn(`[CodeGraph Flows] LLM attempt ${attempt + 1}: validation failed`);
     } catch (err) {
+      if (err instanceof LLMRateLimitError || err instanceof LLMConfigError) throw err;
       console.warn(`[CodeGraph Flows] LLM attempt ${attempt + 1} error:`, err);
     }
   }


### PR DESCRIPTION
## Problem

When the LLM quota was exceeded or the API key was invalid, all errors were silently swallowed in the agent and flow service retry loops. The user got no feedback and the graph was created with heuristic grouping anyway, with no indication anything went wrong.

## Changes

**`llmService.ts`**
- New `LLMRateLimitError` class for 429 / quota exceeded responses
- Each provider detects its specific signals:
  - Gemini: `RESOURCE_EXHAUSTED`, `429`, `quota` in error message
  - OpenAI: `err.status === 429`
  - Anthropic: `response.status === 429`
- 401/403 responses now throw `LLMConfigError` (invalid key) instead of a generic error

**`codeGraphAgentService.ts`** + **`codeGraphFlowService.ts`**
- Retry loop catch blocks re-throw `LLMRateLimitError` and `LLMConfigError` immediately instead of retrying — these errors won't be resolved by retrying

**`useCodeGraph.ts`**
- `loadDemoGraph` outer catch re-throws both error types to App.tsx

**`App.tsx`**
- `handleCreateGraph`, `handleRegenerateFlows`, `onLoadDemoGraph` each catch `LLMRateLimitError` and show its message as an error toast (e.g. *"Gemini quota or rate limit exceeded. Wait a moment then try again."*)

## Test plan

- [x] Exhaust the Gemini quota → toast with clear message, no silent fallback
- [ ] Use an invalid API key → `LLMConfigError` toast + AI Settings opens
- [ ] Normal errors (network, JSON parse) → still fall back to heuristics silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)