### PR TITLE
fix: persist demo CodeGraph to localStorage on load

### DIFF
--- a/hooks/useCodeGraph.ts
+++ b/hooks/useCodeGraph.ts
@@ -386,10 +386,10 @@ export const useCodeGraph = (activeWorkspaceId: string) => {
         setIsGeneratingFlows(false);
       }
 
-      onLogEntry?.('info', `Demo graph ready (${Object.keys(graph.nodes).length} nodes) — not saved yet`);
+      onLogEntry?.('info', `Demo graph ready (${Object.keys(graph.nodes).length} nodes)`);
 
       setCodeGraphs(prev => [...prev, graph]);
-      // Not persisted automatically — user must save explicitly
+      codeGraphStorageService.saveCodeGraph(graph);
       setActiveGraphId(graph.id);
       return graph;
 


### PR DESCRIPTION
## Summary
- The demo CodeGraph (loaded via "Load demo (BlueLens repo)") was added to in-memory state only — it disappeared on page reload
- Now calls `codeGraphStorageService.saveCodeGraph()` like `createGraph` and `createGithubGraph` already do

Closes #45

## Test plan
- [ ] Load the demo graph via the sidebar button
- [ ] Reload the page — the demo graph should still appear in the Code Graphs list
- [ ] Deleting the graph should still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)