### PR TITLE
feat: add Python and C++ support to CodeGraph

### DIFF
--- a/services/codebaseAnalyzerService.ts
+++ b/services/codebaseAnalyzerService.ts
@@ -22,6 +22,7 @@ const ENTRY_POINT_NAMES = new Set([
   'server.ts', 'server.js', 'server.py',
   'mod.rs', 'lib.rs', 'main.rs',
   'setup.py', '__main__.py',
+  'main.cpp', 'main.cc', 'main.c',
 ]);
 
 function matchesGlob(path: string, pattern: string): boolean {

--- a/services/githubDemoService.ts
+++ b/services/githubDemoService.ts
@@ -34,11 +34,17 @@ export const DEMO_RAW_BASE = buildRawBase(DEMO_OWNER, DEMO_REPO, DEMO_BRANCH);
 
 export type DemoProgressCallback = (step: string, current: number, total: number) => void;
 
-const INCLUDED_EXTENSIONS = new Set(['.ts', '.tsx']);
+const INCLUDED_EXTENSIONS = new Set([
+  '.ts', '.tsx',
+  '.py',
+  '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp',
+]);
 
 const ENTRY_POINT_NAMES = new Set([
   'index.ts', 'index.tsx', 'App.tsx', 'App.ts',
   'main.ts', 'main.tsx', 'main.js',
+  'main.py', 'app.py', '__main__.py', 'setup.py',
+  'main.cpp', 'main.cc', 'main.c',
 ]);
 
 interface GithubTreeItem {
@@ -54,6 +60,9 @@ interface GithubTreeResponse {
 function getLanguage(filePath: string): string {
   const ext = filePath.substring(filePath.lastIndexOf('.')).toLowerCase();
   if (ext === '.ts' || ext === '.tsx') return 'typescript';
+  if (ext === '.py') return 'python';
+  if (ext === '.cpp' || ext === '.cc' || ext === '.cxx' || ext === '.h' || ext === '.hpp') return 'cpp';
+  if (ext === '.c') return 'c';
   return 'plaintext';
 }
 


### PR DESCRIPTION
## Summary
- **`codeParserService.ts`**: adds full parsing support for C/C++ and completes Python support
  - `CPP_PATTERNS`: detects `class`/`struct` definitions, function definitions (`{`) and declarations (`;` in headers)
  - `C_PATTERNS`: detects `struct` definitions and function definitions
  - `extractCppImports()`: parses `#include <system>` (external) and `#include "local"` (internal)
  - `extractCppClassHierarchy()`: handles `class Foo : public Bar, protected Baz` inheritance syntax
  - All dispatchers updated: `extractImports`, `extractExports`, `extractClassHierarchy`, call-ref scope detection
- **`githubDemoService.ts`**: expands file extension filter and language detection to include `.py`, `.cpp`, `.cc`, `.cxx`, `.c`, `.h`, `.hpp`
- **`codebaseAnalyzerService.ts`**: adds `main.cpp`, `main.cc`, `main.c` to entry point detection

Closes #47

## Test plan
- [ ] Load a local Python repo — classes and `def` functions appear as nodes in the CodeGraph
- [ ] Load a local C++ repo — classes/structs and function definitions appear as nodes
- [ ] `#include` directives create dependency edges between modules
- [ ] Class inheritance (`class Foo : public Bar`) creates `inherits` relations
- [ ] Existing TypeScript/JavaScript support is not regressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)