### PR TITLE
fix: add solid dark background to SVG export

### DIFF
--- a/components/Preview.tsx
+++ b/components/Preview.tsx
@@ -231,7 +231,15 @@ export const Preview: React.FC<PreviewProps> = ({
     const svgElement = svgDiv?.querySelector('svg');
     if (!svgElement) return;
 
-    const svgData = new XMLSerializer().serializeToString(svgElement);
+    // Clone and inject a solid background so the export isn't transparent
+    const clone = svgElement.cloneNode(true) as SVGSVGElement;
+    const bg = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+    bg.setAttribute('width', '100%');
+    bg.setAttribute('height', '100%');
+    bg.setAttribute('fill', '#0d0d0d');
+    clone.insertBefore(bg, clone.firstChild);
+
+    const svgData = new XMLSerializer().serializeToString(clone);
     const blob = new Blob([svgData], { type: 'image/svg+xml;charset=utf-8' });
     const url = URL.createObjectURL(blob);
     


### PR DESCRIPTION
## Summary
- The exported SVG had a transparent background, making diagram elements invisible on white backgrounds (e.g. when pasting into docs or Figma)
- Fix: clone the SVG element, inject a `<rect fill="#0d0d0d" width="100%" height="100%">` as the first child before serializing — the original DOM is not mutated

Closes #51

## Test plan
- [x] Open a diagram, click the download SVG button
- [x] Open the downloaded file in a browser or image viewer — background should be dark (`#0d0d0d`), not transparent
- [x] Confirm diagram elements (nodes, arrows, labels) are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)