### PR TITLE
fix: export flows to diagram panel after Generate Flows

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -342,9 +342,9 @@ export default function App() {
   const handleRegenerateFlows = useCallback(
     async (options?: { scopeNodeId?: string; customPrompt?: string }) => {
       try {
-        await codeGraph.regenerateFlows(llmSettings, options);
-        // Export only flows at the scope that was regenerated
-        if (codeGraph.activeGraph) triggerFlowExport(codeGraph.activeGraph, options?.scopeNodeId);
+        const updated = await codeGraph.regenerateFlows(llmSettings, options);
+        // Use the returned graph directly — codeGraph.activeGraph is a stale closure here
+        if (updated) triggerFlowExport(updated, options?.scopeNodeId);
       } catch (err: any) {
         if (err instanceof LLMRateLimitError) {
           showToast(err.message, 'error');
@@ -356,7 +356,7 @@ export default function App() {
         }
       }
     },
-    [codeGraph.regenerateFlows, codeGraph.activeGraph, llmSettings, triggerFlowExport, showToast, setIsAISettingsOpen]
+    [codeGraph.regenerateFlows, llmSettings, triggerFlowExport, showToast, setIsAISettingsOpen]
   );
 
   const handleSaveCodeGraphConfig = useCallback((config: import('./types').CodeGraphConfig) => {

--- a/hooks/useCodeGraph.ts
+++ b/hooks/useCodeGraph.ts
@@ -433,8 +433,8 @@ export const useCodeGraph = (activeWorkspaceId: string) => {
   const regenerateFlows = useCallback(async (
     llmSettings?: LLMSettings,
     options?: FlowGenerationOptions,
-  ) => {
-    if (!activeGraph) return;
+  ): Promise<CodeGraph | undefined> => {
+    if (!activeGraph) return undefined;
 
     setIsGeneratingFlows(true);
     setActiveFlowId(null);
@@ -449,7 +449,7 @@ export const useCodeGraph = (activeWorkspaceId: string) => {
       // If generation returned nothing, preserve existing flows
       if (Object.keys(flowResult.flows).length === 0) {
         console.warn('[CodeGraph] Flow generation returned 0 flows, keeping existing');
-        return;
+        return undefined;
       }
 
       let mergedFlows: Record<string, import('../types').GraphFlow>;
@@ -478,6 +478,7 @@ export const useCodeGraph = (activeWorkspaceId: string) => {
         updatedAt: Date.now(),
       };
       updateGraph(updated);
+      return updated;
     } finally {
       setIsGeneratingFlows(false);
       setGraphCreationProgress(null);


### PR DESCRIPTION
## Summary

**Root cause:** `handleRegenerateFlows` in `App.tsx` called `triggerFlowExport(codeGraph.activeGraph, ...)` after an `await`. But `codeGraph.activeGraph` is a stale closure — it captures the graph value at render time, before `regenerateFlows` updated the React state. For a first-time generation (no existing flows), the stale graph has `flows: {}`, so `triggerFlowExport` bails out immediately with no export.

**Fix:** `regenerateFlows()` now returns the updated `CodeGraph` directly (like `createGraph()` already does), and `handleRegenerateFlows` uses that return value instead of the stale closure.

Closes #53

## Test plan
- [ ] Open a CodeGraph with no existing flows → click "Generate Flows" → diagrams should appear in the sidebar panel
- [ ] Regenerate flows on an existing graph → confirm the modal still appears and overwrite/new both work with the latest flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)