### PR TITLE
security: enable TypeScript strict mode and fix dompurify XSS

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -541,7 +541,7 @@ export default function App() {
       if (existing) {
         codeGraph.selectGraph(existing.id);
         showToast('A Code Graph already exists for this repo. Use Re-parse to regenerate it.', 'info');
-        return;
+        return null;
       }
     }
 

--- a/components/Preview.tsx
+++ b/components/Preview.tsx
@@ -336,12 +336,7 @@ export const Preview: React.FC<PreviewProps> = ({
              }}
              className="relative"
            >
-              {/* Sub-diagram badge */}
-              {currentDiagram?.hasSubDiagram && (
-                <SubDiagramBadge onZoomIn={onZoomIn} />
-              )}
-
-              <div 
+<div 
                  className="mermaid-svg-container"
                  dangerouslySetInnerHTML={{ __html: svgContent }} 
               />

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -42,7 +42,7 @@ interface SidebarProps {
   codeGraphs?: CodeGraph[];
   activeGraphId?: string | null;
   onSelectGraph?: (graphId: string | null) => void;
-  onCreateGraph?: (repoId: string) => Promise<CodeGraph | null>;
+  onCreateGraph?: (repoId: string, commitSha?: string) => Promise<CodeGraph | null>;
   onDeleteGraph?: (graphId: string) => void;
   onLoadDemoGraph?: () => void;
   isDemoLoading?: boolean;

--- a/components/WorkspaceView.tsx
+++ b/components/WorkspaceView.tsx
@@ -49,7 +49,7 @@ interface WorkspaceViewProps {
   onGenerateScaffold?: (language: string) => void;
   leftWidthPercent: number;
   isDragging: boolean;
-  containerRef: React.RefObject<HTMLDivElement>;
+  containerRef: React.RefObject<HTMLDivElement | null>;
   onMouseDown: (e: React.MouseEvent) => void;
   // CodeGraph
   codeGraph?: CodeGraph | null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
       },
       "devDependencies": {
         "@types/node": "^22.14.0",
+        "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.0.0",
         "typescript": "~5.8.2",
         "vite": "^6.2.0"
@@ -1760,6 +1761,16 @@
         "csstype": "^3.2.2"
       }
     },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -2930,10 +2941,13 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
-      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
+      "integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
+      "engines": {
+        "node": ">=20"
+      },
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -4946,15 +4960,6 @@
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
-      }
-    },
-    "node_modules/monaco-editor/node_modules/dompurify": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/monaco-editor/node_modules/marked": {

--- a/package.json
+++ b/package.json
@@ -27,8 +27,12 @@
   },
   "devDependencies": {
     "@types/node": "^22.14.0",
+    "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.0.0",
     "typescript": "~5.8.2",
     "vite": "^6.2.0"
+  },
+  "overrides": {
+    "dompurify": "^3.3.2"
   }
 }

--- a/services/llmService.ts
+++ b/services/llmService.ts
@@ -3,7 +3,7 @@
  * Supports Gemini, OpenAI, and Anthropic (via CORS proxy).
  */
 
-import { GoogleGenAI } from '@google/genai';
+import { GoogleGenAI, Type as GeminiType } from '@google/genai';
 import OpenAI from 'openai';
 import { LLMMessage, LLMResponse, LLMSettings, LLMProvider, LLMProviderConfig, AgentToolStep } from '../types';
 import type { AgentToolDefinition } from './agentToolService';
@@ -68,8 +68,9 @@ async function sendGemini(
       config: {
         systemInstruction: systemPrompt,
         temperature: 0.3,
+        abortSignal: signal,
       },
-    }, signal ? { signal } : undefined);
+    });
 
     const text = response.text;
     if (!text) throw new Error('No response from Gemini');
@@ -196,10 +197,24 @@ async function runAgentLoopGemini(
         parts: [{ text: m.content }],
       }));
 
+  const geminiTypeMap: Record<string, GeminiType> = {
+    string: GeminiType.STRING,
+    number: GeminiType.NUMBER,
+    boolean: GeminiType.BOOLEAN,
+  };
   const functionDeclarations = tools.map(t => ({
     name: t.name,
     description: t.description,
-    parameters: t.parameters,
+    parameters: {
+      type: GeminiType.OBJECT,
+      properties: Object.fromEntries(
+        Object.entries(t.parameters.properties).map(([key, param]) => [
+          key,
+          { ...param, type: geminiTypeMap[param.type] ?? GeminiType.STRING },
+        ])
+      ),
+      required: t.parameters.required,
+    },
   }));
 
   for (let i = 0; i < MAX_AGENT_ITERATIONS; i++) {
@@ -211,8 +226,9 @@ async function runAgentLoopGemini(
         systemInstruction: systemPrompt,
         temperature: 0.3,
         tools: [{ functionDeclarations }],
+        abortSignal: signal,
       },
-    }, signal ? { signal } : undefined);
+    });
 
     const candidate = response.candidates?.[0];
     if (!candidate?.content?.parts) throw new Error('No response from Gemini');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
       "DOM",
       "DOM.Iterable"
     ],
+    "strict": true,
     "skipLibCheck": true,
     "types": [
       "node"


### PR DESCRIPTION
## Description

Closes #70, closes #71

Two security improvements in a single PR:

### 1. TypeScript strict mode (`#70`)

Added `"strict": true` to `tsconfig.json` and resolved all 9 resulting type errors:

| File | Fix |
|------|-----|
| `tsconfig.json` | Added `"strict": true` |
| `package.json` (devDeps) | Added missing `@types/react-dom` |
| `components/WorkspaceView.tsx` | `RefObject<HTMLDivElement>` → `RefObject<HTMLDivElement \| null>` (React 19) |
| `App.tsx` | Explicit `return null` instead of implicit `undefined` in `handleCreateGraph` |
| `components/Sidebar.tsx` | `onCreateGraph` prop type accepts optional `commitSha` |
| `components/Preview.tsx` | Removed stale `hasSubDiagram` check (property never existed on `Diagram`) |
| `services/llmService.ts` | Map `AgentToolParam` types to Gemini `Type` enum for strict `Schema` typing |
| `services/llmService.ts` | Move `AbortSignal` to `config.abortSignal` per Gemini SDK v1 API (was incorrectly passed as 2nd argument) |

### 2. dompurify XSS vulnerability (`#71`)

- Added `"overrides": { "dompurify": "^3.3.2" }` to `package.json`
- Forces all transitive copies (including monaco-editor's bundled 3.2.7) to the patched version
- `npm audit` now reports **0 vulnerabilities**

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactor (no behavior change)

## How to test

1. Run `npx tsc --noEmit` — should produce 0 errors
2. Run `npm audit` — should report 0 vulnerabilities
3. Run `npm run build` — should complete without errors
4. Verify the app loads and AI chat / code graph features work normally

## Security checklist

- [x] No API keys, tokens, or secrets are hardcoded or committed
- [x] `.env` is not included in this PR
- [x] No new `eval()`, `Function()`, or unsanitized `innerHTML` usage
- [x] Any new `dangerouslySetInnerHTML` usage only renders content from trusted internal sources — N/A (none added)
- [x] No new dependencies added without justification — `@types/react-dom` is a type-only devDependency for existing `react-dom` usage
- [x] New dependencies have been checked for known vulnerabilities — `npm audit` reports 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)