### PR TITLE
security: type LLM responses and surface crypto fallback warning

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -25,7 +25,7 @@ import { useRepoHandlers } from './hooks/useRepoHandlers';
 import { useCodeLinkHandlers } from './hooks/useCodeLinkHandlers';
 import { useSplitPane } from './hooks/useSplitPane';
 import { useStoragePersistence } from './hooks/useStoragePersistence';
-import { useLLMSettings } from './hooks/useLLMSettings';
+import { useLLMSettings, storageInsecure } from './hooks/useLLMSettings';
 import { useChatHandlers } from './hooks/useChatHandlers';
 import { useScanHandlers } from './hooks/useScanHandlers'; // TODO(DELETE): SCAN FEATURE
 import { useCodebaseImport } from './hooks/useCodebaseImport';
@@ -1049,6 +1049,7 @@ export default function App() {
         onCloseAISettings={() => setIsAISettingsOpen(false)}
         onUpdateProvider={updateProvider}
         onSetActiveProvider={setActiveProvider}
+        storageInsecure={storageInsecure}
         // TODO(DELETE): SCAN FEATURE — remove these 11 props
         isScanResultsOpen={isScanResultsOpen}
         onCloseScanResults={() => { setIsScanResultsOpen(false); clearScanResult(); }}

--- a/components/AISettingsModal.tsx
+++ b/components/AISettingsModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { X, Check, AlertCircle, Loader2, ChevronDown } from 'lucide-react';
+import { X, Check, AlertCircle, Loader2, ChevronDown, ShieldAlert } from 'lucide-react';
 import { Button } from './Button';
 import { LLMProvider, LLMProviderConfig, LLMSettings } from '../types';
 import { llmService } from '../services/llmService';
@@ -10,6 +10,7 @@ interface AISettingsModalProps {
   llmSettings: LLMSettings;
   onUpdateProvider: (provider: LLMProvider, config: LLMProviderConfig | null) => void;
   onSetActiveProvider: (provider: LLMProvider) => void;
+  storageInsecure?: boolean;
 }
 
 const PROVIDER_INFO: Record<LLMProvider, { label: string; description: string }> = {
@@ -65,6 +66,7 @@ export const AISettingsModal: React.FC<AISettingsModalProps> = ({
   llmSettings,
   onUpdateProvider,
   onSetActiveProvider,
+  storageInsecure = false,
 }) => {
   const [testingProvider, setTestingProvider] = useState<LLMProvider | null>(null);
   const [testResults, setTestResults] = useState<Record<string, 'success' | 'error' | null>>({});
@@ -131,6 +133,14 @@ export const AISettingsModal: React.FC<AISettingsModalProps> = ({
 
         {/* Body */}
         <div className="p-6 space-y-6 overflow-y-auto">
+          {storageInsecure && (
+            <div className="flex items-start gap-3 p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/30">
+              <ShieldAlert className="w-4 h-4 text-yellow-400 flex-shrink-0 mt-0.5" />
+              <p className="text-xs text-yellow-300 leading-relaxed">
+                <span className="font-semibold">Encrypted storage unavailable.</span> Your browser does not support IndexedDB or Web Crypto API. API keys are stored in plaintext localStorage. Use a modern Chromium-based browser (Chrome, Edge, Brave) for encrypted key storage.
+              </p>
+            </div>
+          )}
           {PROVIDER_ORDER.map(provider => {
             const info = PROVIDER_INFO[provider];
             const config = llmSettings.providers[provider];

--- a/components/ModalManager.tsx
+++ b/components/ModalManager.tsx
@@ -49,6 +49,7 @@ interface ModalManagerProps {
   onCloseAISettings: () => void;
   onUpdateProvider: (provider: LLMProvider, config: LLMProviderConfig | null) => void;
   onSetActiveProvider: (provider: LLMProvider) => void;
+  storageInsecure?: boolean;
   // Scan Results
   isScanResultsOpen: boolean;
   onCloseScanResults: () => void;
@@ -125,6 +126,7 @@ export const ModalManager: React.FC<ModalManagerProps> = ({
   onCloseAISettings,
   onUpdateProvider,
   onSetActiveProvider,
+  storageInsecure,
   isScanResultsOpen,
   onCloseScanResults,
   scanResult,
@@ -221,6 +223,7 @@ export const ModalManager: React.FC<ModalManagerProps> = ({
         llmSettings={llmSettings}
         onUpdateProvider={onUpdateProvider}
         onSetActiveProvider={onSetActiveProvider}
+        storageInsecure={storageInsecure}
       />
 
       {/* Scan Results Panel */}

--- a/hooks/useLLMSettings.ts
+++ b/hooks/useLLMSettings.ts
@@ -3,6 +3,10 @@ import { LLMSettings, LLMProvider, LLMProviderConfig } from '../types';
 import { getDefaultSettings } from '../services/llmService';
 import { cryptoStorageService } from '../services/cryptoStorageService';
 
+/** True when the browser does not support encrypted storage (IndexedDB + Web Crypto).
+ *  In this case API keys are stored in plaintext localStorage. */
+export const storageInsecure = !cryptoStorageService.isSupported();
+
 const STORAGE_KEY = 'mermaidviz_llm_settings';
 const SECURE_KEY = 'llm_settings';
 

--- a/services/llmService.ts
+++ b/services/llmService.ts
@@ -4,7 +4,9 @@
  */
 
 import { GoogleGenAI, Type as GeminiType } from '@google/genai';
+import type { Content, Part } from '@google/genai';
 import OpenAI from 'openai';
+import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
 import { LLMMessage, LLMResponse, LLMSettings, LLMProvider, LLMProviderConfig, AgentToolStep } from '../types';
 import type { AgentToolDefinition } from './agentToolService';
 
@@ -47,6 +49,23 @@ const DEFAULT_MODELS: Record<LLMProvider, string> = {
   anthropic: 'claude-sonnet-4-6',
 };
 
+// ─── Anthropic response shapes (raw fetch — no official browser SDK) ──────────
+
+interface AnthropicContentBlock {
+  type: 'text' | 'tool_use';
+  text?: string;
+  id?: string;
+  name?: string;
+  input?: Record<string, unknown>;
+}
+
+interface AnthropicMessage {
+  role: 'user' | 'assistant';
+  content: string | AnthropicContentBlock[];
+}
+
+// ─── Simple send (no tool use) ────────────────────────────────────────────────
+
 async function sendGemini(
   messages: LLMMessage[],
   systemPrompt: string,
@@ -56,7 +75,7 @@ async function sendGemini(
   const ai = new GoogleGenAI({ apiKey: config.apiKey });
   const model = config.model || DEFAULT_MODELS.gemini;
 
-  const contents = messages.map(m => ({
+  const contents: Content[] = messages.map(m => ({
     role: m.role === 'assistant' ? 'model' as const : 'user' as const,
     parts: [{ text: m.content }],
   }));
@@ -76,9 +95,9 @@ async function sendGemini(
     if (!text) throw new Error('No response from Gemini');
 
     return { content: text, provider: 'gemini', model };
-  } catch (err: any) {
+  } catch (err: unknown) {
     if (err instanceof LLMConfigError || err instanceof LLMRateLimitError) throw err;
-    const msg: string = err?.message ?? '';
+    const msg = err instanceof Error ? err.message : String(err);
     if (msg.includes('429') || msg.includes('RESOURCE_EXHAUSTED') || msg.includes('quota')) {
       throw new LLMRateLimitError('Gemini');
     }
@@ -119,9 +138,9 @@ async function sendOpenAI(
     if (!text) throw new Error('No response from OpenAI');
 
     return { content: text, provider: 'openai', model };
-  } catch (err: any) {
+  } catch (err: unknown) {
     if (err instanceof LLMConfigError || err instanceof LLMRateLimitError) throw err;
-    const status: number | undefined = err?.status;
+    const status = err instanceof OpenAI.APIError ? err.status : undefined;
     if (status === 429) throw new LLMRateLimitError('OpenAI');
     if (status === 401 || status === 403) throw new LLMConfigError(`OpenAI API key is invalid. Open AI Settings.`);
     throw err;
@@ -168,7 +187,7 @@ async function sendAnthropic(
     throw new Error(`Anthropic API error (${response.status}): ${errorText}`);
   }
 
-  const data = await response.json();
+  const data = await response.json() as { content: AnthropicContentBlock[] };
   const text = data.content?.[0]?.text;
   if (!text) throw new Error('No response from Anthropic');
 
@@ -190,10 +209,10 @@ async function runAgentLoopGemini(
   const model = config.model || DEFAULT_MODELS.gemini;
   const toolSteps: AgentToolStep[] = [];
 
-  const contents: any[] = continuationContext
-    ? [...continuationContext]
+  const contents: Content[] = continuationContext
+    ? [...continuationContext] as Content[]
     : messages.map(m => ({
-        role: m.role === 'assistant' ? 'model' : 'user',
+        role: m.role === 'assistant' ? 'model' as const : 'user' as const,
         parts: [{ text: m.content }],
       }));
 
@@ -233,21 +252,22 @@ async function runAgentLoopGemini(
     const candidate = response.candidates?.[0];
     if (!candidate?.content?.parts) throw new Error('No response from Gemini');
 
-    const parts = candidate.content.parts;
-    const fnParts = parts.filter((p: any) => p.functionCall);
-    const textParts = parts.filter((p: any) => p.text);
+    const parts: Part[] = candidate.content.parts;
+    const fnParts = parts.filter(p => p.functionCall != null);
+    const textParts = parts.filter(p => p.text != null);
 
     if (fnParts.length === 0) {
-      return { content: textParts.map((p: any) => p.text).join(''), toolSteps };
+      return { content: textParts.map(p => p.text ?? '').join(''), toolSteps };
     }
 
     // Add model turn with all parts
     contents.push({ role: 'model', parts });
 
     // Execute tool calls in parallel when the LLM batches multiple in one turn
-    const fnResponses = await Promise.all(fnParts.map(async (part: any) => {
-      const { name, args } = part.functionCall;
-      const step = await executor(name, args ?? {});
+    const fnResponses = await Promise.all(fnParts.map(async part => {
+      const { name, args } = part.functionCall!;
+      if (!name) throw new Error('Gemini returned a function call with no name');
+      const step = await executor(name, (args ?? {}) as Record<string, unknown>);
       toolSteps.push(step);
       return { functionResponse: { name, response: { output: step.result } } };
     }));
@@ -277,12 +297,11 @@ async function runAgentLoopOpenAI(
     function: { name: t.name, description: t.description, parameters: t.parameters },
   }));
 
-  // continuationContext already includes the system message when resuming
-  const conv: any[] = continuationContext
-    ? [...continuationContext]
+  const conv: ChatCompletionMessageParam[] = continuationContext
+    ? [...continuationContext] as ChatCompletionMessageParam[]
     : [
         { role: 'system', content: systemPrompt },
-        ...messages.map(m => ({ role: m.role, content: m.content })),
+        ...messages.map(m => ({ role: m.role as 'user' | 'assistant', content: m.content })),
       ];
 
   for (let i = 0; i < MAX_AGENT_ITERATIONS; i++) {
@@ -305,8 +324,8 @@ async function runAgentLoopOpenAI(
     }
 
     // Execute tool calls in parallel when the LLM batches multiple in one turn
-    const toolMessages = await Promise.all(msg.tool_calls.map(async (tc: any) => {
-      const args = JSON.parse(tc.function.arguments || '{}');
+    const toolMessages = await Promise.all(msg.tool_calls.filter(tc => tc.type === 'function').map(async tc => {
+      const args = JSON.parse(tc.function.arguments || '{}') as Record<string, unknown>;
       const step = await executor(tc.function.name, args);
       toolSteps.push(step);
       return { role: 'tool' as const, tool_call_id: tc.id, content: step.result };
@@ -338,9 +357,9 @@ async function runAgentLoopAnthropic(
     input_schema: t.parameters,
   }));
 
-  const conv: any[] = continuationContext
-    ? [...continuationContext]
-    : messages.map(m => ({ role: m.role, content: m.content }));
+  const conv: AnthropicMessage[] = continuationContext
+    ? [...continuationContext] as AnthropicMessage[]
+    : messages.map(m => ({ role: m.role as 'user' | 'assistant', content: m.content }));
 
   for (let i = 0; i < MAX_AGENT_ITERATIONS; i++) {
     signal?.throwIfAborted();
@@ -368,26 +387,29 @@ async function runAgentLoopAnthropic(
       throw new Error(`Anthropic error (${res.status}): ${text}`);
     }
 
-    const data = await res.json();
-    const content: any[] = data.content ?? [];
-    const stopReason: string = data.stop_reason;
+    const data = await res.json() as { content: AnthropicContentBlock[]; stop_reason: string };
+    const content = data.content ?? [];
+    const stopReason = data.stop_reason;
 
     // Add assistant turn
     conv.push({ role: 'assistant', content });
 
     if (stopReason !== 'tool_use') {
-      const text = content.filter((b: any) => b.type === 'text').map((b: any) => b.text).join('');
+      const text = content
+        .filter(b => b.type === 'text')
+        .map(b => b.text ?? '')
+        .join('');
       return { content: text, toolSteps };
     }
 
     // Execute tool use blocks in parallel when the LLM batches multiple in one turn
-    const toolUseBlocks = content.filter((b: any) => b.type === 'tool_use');
-    const toolResults = await Promise.all(toolUseBlocks.map(async (block: any) => {
-      const step = await executor(block.name, block.input ?? {});
+    const toolUseBlocks = content.filter(b => b.type === 'tool_use');
+    const toolResults = await Promise.all(toolUseBlocks.map(async block => {
+      const step = await executor(block.name!, block.input ?? {});
       toolSteps.push(step);
-      return { type: 'tool_result', tool_use_id: block.id, content: step.result };
+      return { type: 'tool_result', tool_use_id: block.id!, content: step.result };
     }));
-    conv.push({ role: 'user', content: toolResults });
+    conv.push({ role: 'user', content: toolResults as unknown as AnthropicContentBlock[] });
   }
 
   return { content: '', toolSteps, interrupted: true, continuationContext: [...conv] };


### PR DESCRIPTION
## Description

Closes #72, closes #73

### 1. Type LLM API responses (`#72`)

Removes all `any` usage at the LLM trust boundary in `llmService.ts`:

| Change | Detail |
|--------|--------|
| Gemini conversation history | `any[]` → `Content[]` (from `@google/genai`) |
| Gemini response parts | `filter((p: any) =>)` → typed `Part[]` narrowing |
| OpenAI conversation history | `any[]` → `ChatCompletionMessageParam[]` |
| OpenAI tool calls | `(tc: any)` removed — SDK types inferred; filtered to `type === 'function'` |
| Anthropic response | `data.content: any[]` → `AnthropicContentBlock[]` (new typed interface) |
| Anthropic conversation | `any[]` → `AnthropicMessage[]` (new typed interface) |
| Error handling | `catch (err: any)` → `catch (err: unknown)` + proper narrowing everywhere |
| OpenAI error status | `err?.status` any-cast → `err instanceof OpenAI.APIError` |

### 2. Crypto storage fallback warning (`#73`)

When `IndexedDB` or `Web Crypto` is unavailable, API keys fall back to plaintext `localStorage`. Previously this was silently logged to console only.

**Now:** A yellow warning banner appears inside AI Settings when the fallback is active:

> ⚠️ **Encrypted storage unavailable.** Your browser does not support IndexedDB or Web Crypto API. API keys are stored in plaintext localStorage. Use a modern Chromium-based browser (Chrome, Edge, Brave) for encrypted key storage.

Implementation: `storageInsecure` boolean exported from `useLLMSettings`, threaded through `ModalManager` to `AISettingsModal`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactor (no behavior change)

## How to test

1. `npx tsc --noEmit` → 0 errors
2. `npm run build` → clean build
3. Open AI Settings → no yellow banner in a supported browser
4. To test the warning: temporarily add `|| true` to the `isSupported()` return in `cryptoStorageService.ts`, open AI Settings → yellow banner appears

## Security checklist

- [x] No API keys, tokens, or secrets are hardcoded or committed
- [x] `.env` is not included in this PR
- [x] No new `eval()`, `Function()`, or unsanitized `innerHTML` usage
- [x] Any new `dangerouslySetInnerHTML` — N/A (none added)
- [x] No new dependencies added
- [x] `npm audit` reports 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)