### PR TITLE
feat: pan/zoom visual diff with SVG highlight for added/removed elements

### DIFF
--- a/components/InlineDiagramPreview.tsx
+++ b/components/InlineDiagramPreview.tsx
@@ -3,11 +3,12 @@ import mermaid from 'mermaid';
 
 interface InlineDiagramPreviewProps {
   code: string;
+  postProcessSvg?: (svg: string) => string;
 }
 
 let _globalIdCounter = 0;
 
-export const InlineDiagramPreview: React.FC<InlineDiagramPreviewProps> = ({ code }) => {
+export const InlineDiagramPreview: React.FC<InlineDiagramPreviewProps> = ({ code, postProcessSvg }) => {
   const [view, setView] = useState<'diagram' | 'code'>('diagram');
   const [svg, setSvg] = useState<string>('');
   const [error, setError] = useState<string>('');
@@ -23,7 +24,7 @@ export const InlineDiagramPreview: React.FC<InlineDiagramPreviewProps> = ({ code
     (async () => {
       try {
         const { svg: rendered } = await mermaid.render(id, code);
-        if (!cancelled) setSvg(rendered);
+        if (!cancelled) setSvg(postProcessSvg ? postProcessSvg(rendered) : rendered);
       } catch (err: any) {
         if (!cancelled) setError(err.message || 'Render error');
       }

--- a/components/InlineDiagramPreview.tsx
+++ b/components/InlineDiagramPreview.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import mermaid from 'mermaid';
 
 interface InlineDiagramPreviewProps {
@@ -13,6 +13,14 @@ export const InlineDiagramPreview: React.FC<InlineDiagramPreviewProps> = ({ code
   const [svg, setSvg] = useState<string>('');
   const [error, setError] = useState<string>('');
   const renderId = useRef(`inline-preview-${++_globalIdCounter}`);
+  // Keep a stable ref to postProcessSvg so the effect can use the latest version
+  // without re-running the full mermaid render on every parent re-render.
+  const postProcessRef = useRef(postProcessSvg);
+  postProcessRef.current = postProcessSvg;
+
+  const applyAndSet = useCallback((rendered: string) => {
+    setSvg(postProcessRef.current ? postProcessRef.current(rendered) : rendered);
+  }, []);
 
   useEffect(() => {
     if (!code.trim()) return;
@@ -24,14 +32,14 @@ export const InlineDiagramPreview: React.FC<InlineDiagramPreviewProps> = ({ code
     (async () => {
       try {
         const { svg: rendered } = await mermaid.render(id, code);
-        if (!cancelled) setSvg(postProcessSvg ? postProcessSvg(rendered) : rendered);
+        if (!cancelled) applyAndSet(rendered);
       } catch (err: any) {
         if (!cancelled) setError(err.message || 'Render error');
       }
     })();
 
     return () => { cancelled = true; };
-  }, [code]);
+  }, [code, applyAndSet]);
 
   return (
     <div className="mt-2 rounded-lg border border-gray-800 overflow-hidden text-xs">

--- a/components/SyncDiffModal.tsx
+++ b/components/SyncDiffModal.tsx
@@ -14,12 +14,70 @@ interface SyncDiffModalProps {
 }
 
 // ---------------------------------------------------------------------------
+// SVG diff highlighting for sequence diagrams
+// ---------------------------------------------------------------------------
+
+interface DiffHighlights {
+  actors: Set<string>;
+  edgeLabels: Set<string>;
+  mode: 'added' | 'removed';
+}
+
+function applySequenceHighlights(svgStr: string, highlights: DiffHighlights): string {
+  try {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(svgStr, 'image/svg+xml');
+    if (doc.querySelector('parsererror')) return svgStr;
+
+    const isAdded = highlights.mode === 'added';
+    const fillBg   = isAdded ? 'rgba(34,197,94,0.18)'  : 'rgba(239,68,68,0.18)';
+    const stroke   = isAdded ? '#22c55e'                : '#ef4444';
+    const textFill = isAdded ? '#4ade80'                : '#f87171';
+
+    // --- Actors: <text class="actor"> whose text matches ---
+    for (const textEl of doc.querySelectorAll('text.actor')) {
+      const name = textEl.textContent?.trim() ?? '';
+      if (!highlights.actors.has(name)) continue;
+      const rect = textEl.parentElement?.querySelector('rect');
+      if (rect) {
+        rect.setAttribute('fill', fillBg);
+        rect.setAttribute('stroke', stroke);
+        rect.setAttribute('stroke-width', '2.5');
+      }
+      textEl.setAttribute('fill', textFill);
+    }
+
+    // --- Messages: <text class="messageText"> whose text matches ---
+    for (const textEl of doc.querySelectorAll('text.messageText')) {
+      const label = textEl.textContent?.trim() ?? '';
+      if (!highlights.edgeLabels.has(label)) continue;
+      textEl.setAttribute('fill', textFill);
+      // Scan siblings (backward) for the associated line/path
+      const siblings = textEl.parentElement ? Array.from(textEl.parentElement.children) : [];
+      const idx = siblings.indexOf(textEl as Element);
+      for (let i = idx - 1; i >= 0; i--) {
+        const el = siblings[i] as Element;
+        if (el.tagName === 'line' || el.tagName === 'path') {
+          el.setAttribute('stroke', stroke);
+          el.setAttribute('stroke-width', '2.5');
+          break;
+        }
+      }
+    }
+
+    return new XMLSerializer().serializeToString(doc.documentElement);
+  } catch {
+    return svgStr;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // PanZoomDiagram — independent pan + zoom for each side of the visual diff
 // ---------------------------------------------------------------------------
 
 let _pzCounter = 0;
 
-const PanZoomDiagram: React.FC<{ code: string; label: string }> = ({ code, label }) => {
+const PanZoomDiagram: React.FC<{ code: string; label: string; highlights?: DiffHighlights }> = ({ code, label, highlights }) => {
   const [svg, setSvg] = useState('');
   const [error, setError] = useState('');
   const [t, setT] = useState({ x: 0, y: 0, scale: 1 });
@@ -36,13 +94,13 @@ const PanZoomDiagram: React.FC<{ code: string; label: string }> = ({ code, label
     (async () => {
       try {
         const { svg: rendered } = await mermaid.render(renderId.current, code);
-        if (!cancelled) setSvg(rendered);
+        if (!cancelled) setSvg(highlights ? applySequenceHighlights(rendered, highlights) : rendered);
       } catch (err: any) {
         if (!cancelled) setError(err.message || 'Render error');
       }
     })();
     return () => { cancelled = true; };
-  }, [code]);
+  }, [code, highlights]);
 
   const onWheel = useCallback((e: React.WheelEvent) => {
     e.preventDefault();
@@ -112,8 +170,23 @@ const DualDiagramModal: React.FC<{
   diagramName: string;
   currentCode: string;
   proposedCode: string;
+  addedNodes: string[];
+  removedNodes: string[];
+  addedEdges: Array<{ from: string; to: string; label?: string }>;
+  removedEdges: Array<{ from: string; to: string; label?: string }>;
   onClose: () => void;
-}> = ({ diagramName, currentCode, proposedCode, onClose }) => createPortal(
+}> = ({ diagramName, currentCode, proposedCode, addedNodes, removedNodes, addedEdges, removedEdges, onClose }) => {
+  const beforeHighlights: DiffHighlights = {
+    actors: new Set(removedNodes),
+    edgeLabels: new Set(removedEdges.map(e => e.label ?? `${e.from} → ${e.to}`).filter(Boolean)),
+    mode: 'removed',
+  };
+  const afterHighlights: DiffHighlights = {
+    actors: new Set(addedNodes),
+    edgeLabels: new Set(addedEdges.map(e => e.label ?? `${e.from} → ${e.to}`).filter(Boolean)),
+    mode: 'added',
+  };
+  return createPortal(
   <div className="fixed inset-0 z-[200] flex items-center justify-center p-4">
     <div className="absolute inset-0 bg-black/75 backdrop-blur-sm" onClick={onClose} />
     <div className="relative w-full max-w-7xl h-[88vh] flex flex-col rounded-2xl bg-dark-900 border border-gray-700 shadow-2xl overflow-hidden">
@@ -129,13 +202,14 @@ const DualDiagramModal: React.FC<{
       </div>
       {/* Side-by-side pan/zoom */}
       <div className="flex-1 flex gap-3 p-3 min-h-0">
-        <PanZoomDiagram code={currentCode} label="Before" />
-        <PanZoomDiagram code={proposedCode} label="After" />
+        <PanZoomDiagram code={currentCode} label="Before" highlights={beforeHighlights} />
+        <PanZoomDiagram code={proposedCode} label="After" highlights={afterHighlights} />
       </div>
     </div>
   </div>,
   document.body
-) as React.ReactElement;
+  );
+};
 
 // ---------------------------------------------------------------------------
 
@@ -255,6 +329,19 @@ const DiagramDiffRow: React.FC<{
   const { added: addedLines, removed: removedLines } = summarizeLineDiff(lineDiff);
   const hasChanges = addedLines.length > 0 || removedLines.length > 0;
 
+  const beforeHighlights: DiffHighlights = {
+    actors: new Set(diff.removedNodes),
+    edgeLabels: new Set(diff.removedEdges.map(e => e.label).filter((l): l is string => !!l)),
+    mode: 'removed',
+  };
+  const afterHighlights: DiffHighlights = {
+    actors: new Set(diff.addedNodes),
+    edgeLabels: new Set(diff.addedEdges.map(e => e.label).filter((l): l is string => !!l)),
+    mode: 'added',
+  };
+  const beforePostProcess = useCallback((svg: string) => applySequenceHighlights(svg, beforeHighlights), [diff.removedNodes, diff.removedEdges]); // eslint-disable-line
+  const afterPostProcess = useCallback((svg: string) => applySequenceHighlights(svg, afterHighlights), [diff.addedNodes, diff.addedEdges]); // eslint-disable-line
+
   return (
     <div className="border border-gray-700 rounded-lg overflow-hidden">
       {/* Header row */}
@@ -351,11 +438,11 @@ const DiagramDiffRow: React.FC<{
                 <div className="grid grid-cols-2 gap-4 pointer-events-none">
                   <div className="flex flex-col">
                     <p className="text-[10px] text-gray-500 font-semibold uppercase tracking-wider mb-1.5">Before</p>
-                    <div className="flex-1"><InlineDiagramPreview code={diff.currentCode} /></div>
+                    <div className="flex-1"><InlineDiagramPreview code={diff.currentCode} postProcessSvg={beforePostProcess} /></div>
                   </div>
                   <div className="flex flex-col">
                     <p className="text-[10px] text-gray-500 font-semibold uppercase tracking-wider mb-1.5">After</p>
-                    <div className="flex-1"><InlineDiagramPreview code={diff.annotatedCode} /></div>
+                    <div className="flex-1"><InlineDiagramPreview code={diff.annotatedCode} postProcessSvg={afterPostProcess} /></div>
                   </div>
                 </div>
                 {/* Invisible overlay — shows hint on hover */}
@@ -374,6 +461,10 @@ const DiagramDiffRow: React.FC<{
               diagramName={diff.diagramName}
               currentCode={diff.currentCode}
               proposedCode={diff.annotatedCode}
+              addedNodes={diff.addedNodes}
+              removedNodes={diff.removedNodes}
+              addedEdges={diff.addedEdges}
+              removedEdges={diff.removedEdges}
               onClose={() => setDualExpanded(false)}
             />
           )}

--- a/components/SyncDiffModal.tsx
+++ b/components/SyncDiffModal.tsx
@@ -24,49 +24,74 @@ interface DiffHighlights {
 }
 
 function applySequenceHighlights(svgStr: string, highlights: DiffHighlights): string {
+  if (!highlights.actors.size && !highlights.edgeLabels.size) return svgStr;
   try {
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(svgStr, 'image/svg+xml');
-    if (doc.querySelector('parsererror')) return svgStr;
+    // Use innerHTML (HTML parser) — more robust than DOMParser('image/svg+xml')
+    // which fails on Mermaid's not-quite-valid XML output.
+    const container = document.createElement('div');
+    container.innerHTML = svgStr;
+    const svg = container.querySelector('svg');
+    if (!svg) return svgStr;
 
     const isAdded = highlights.mode === 'added';
-    const fillBg   = isAdded ? 'rgba(34,197,94,0.18)'  : 'rgba(239,68,68,0.18)';
-    const stroke   = isAdded ? '#22c55e'                : '#ef4444';
-    const textFill = isAdded ? '#4ade80'                : '#f87171';
+    const fillBg  = isAdded ? 'rgba(34,197,94,0.22)' : 'rgba(239,68,68,0.22)';
+    const stroke  = isAdded ? '#22c55e'               : '#ef4444';
+    const textCol = isAdded ? '#4ade80'               : '#f87171';
 
-    // --- Actors: <text class="actor"> whose text matches ---
-    for (const textEl of doc.querySelectorAll('text.actor')) {
-      const name = textEl.textContent?.trim() ?? '';
+    // --- Actors ---
+    for (const group of svg.querySelectorAll('g.actor, g[class~="actor"]')) {
+      // The display label is in the deepest text-like node
+      const textEl = group.querySelector('text') ?? group.querySelector('span');
+      const name = textEl?.textContent?.trim() ?? '';
       if (!highlights.actors.has(name)) continue;
-      const rect = textEl.parentElement?.querySelector('rect');
+      const rect = group.querySelector('rect');
       if (rect) {
         rect.setAttribute('fill', fillBg);
         rect.setAttribute('stroke', stroke);
         rect.setAttribute('stroke-width', '2.5');
       }
-      textEl.setAttribute('fill', textFill);
+      if (textEl) textEl.setAttribute('fill', textCol);
     }
 
-    // --- Messages: <text class="messageText"> whose text matches ---
-    for (const textEl of doc.querySelectorAll('text.messageText')) {
-      const label = textEl.textContent?.trim() ?? '';
-      if (!highlights.edgeLabels.has(label)) continue;
-      textEl.setAttribute('fill', textFill);
-      // Scan siblings (backward) for the associated line/path
-      const siblings = textEl.parentElement ? Array.from(textEl.parentElement.children) : [];
-      const idx = siblings.indexOf(textEl as Element);
-      for (let i = idx - 1; i >= 0; i--) {
-        const el = siblings[i] as Element;
-        if (el.tagName === 'line' || el.tagName === 'path') {
-          el.setAttribute('stroke', stroke);
-          el.setAttribute('stroke-width', '2.5');
-          break;
+    // --- Messages ---
+    // Collect all messageLine elements and messageText elements in DOM order.
+    // In Mermaid sequence SVGs they appear as flat siblings: line then text, interleaved.
+    const allLines = Array.from(svg.querySelectorAll('line[class*="messageLine"], path[class*="messageLine"]'));
+    const allMsgTextEls = Array.from(svg.querySelectorAll('text[class*="messageText"]'));
+
+    console.debug('[BlueLens diff] highlight labels:', [...highlights.edgeLabels]);
+    console.debug('[BlueLens diff] messageLine count:', allLines.length, '| messageText count:', allMsgTextEls.length);
+    console.debug('[BlueLens diff] messageText contents:', allMsgTextEls.map(el => JSON.stringify(el.textContent?.trim())));
+
+    allMsgTextEls.forEach((msgEl, idx) => {
+      const label = msgEl.textContent?.trim() ?? '';
+      if (!highlights.edgeLabels.has(label)) return;
+      msgEl.setAttribute('fill', textCol);
+      // Associated line: same index, or scan backwards through siblings
+      const line = allLines[idx];
+      if (line) {
+        line.setAttribute('stroke', stroke);
+        line.setAttribute('stroke-width', '3');
+      }
+      // Fallback: scan backward siblings for any line/path
+      const parent = msgEl.parentElement;
+      if (parent && !line) {
+        const children = Array.from(parent.children);
+        const i = children.indexOf(msgEl);
+        for (let k = i - 1; k >= 0; k--) {
+          const el = children[k];
+          if (el.tagName === 'line' || el.tagName === 'path') {
+            el.setAttribute('stroke', stroke);
+            el.setAttribute('stroke-width', '3');
+            break;
+          }
         }
       }
-    }
+    });
 
-    return new XMLSerializer().serializeToString(doc.documentElement);
-  } catch {
+    return container.innerHTML;
+  } catch (e) {
+    console.error('[BlueLens] SVG highlight error:', e);
     return svgStr;
   }
 }

--- a/components/SyncDiffModal.tsx
+++ b/components/SyncDiffModal.tsx
@@ -43,18 +43,19 @@ function applyDiffHighlights(svgStr: string, highlights: DiffHighlights): string
     const strokeW = '3';
     const textCol = isAdded ? '#14532d' : '#7f1d1d';
 
+    // Helper: apply inline styles (override Mermaid's embedded <style> block via CSS cascade)
+    const styleEl = (el: Element, props: Record<string, string>) => {
+      for (const [k, v] of Object.entries(props)) (el as HTMLElement).style.setProperty(k, v);
+    };
+
     // --- Sequence: actors ---
     for (const group of svg.querySelectorAll('g.actor, g[class~="actor"]')) {
       const textEl = group.querySelector('text') ?? group.querySelector('span');
       const name = textEl?.textContent?.trim() ?? '';
       if (!highlights.actors.has(name)) continue;
       const rect = group.querySelector('rect');
-      if (rect) {
-        rect.setAttribute('fill', fillBg);
-        rect.setAttribute('stroke', stroke);
-        rect.setAttribute('stroke-width', strokeW);
-      }
-      if (textEl) textEl.setAttribute('fill', textCol);
+      if (rect) styleEl(rect, { fill: fillBg, stroke, 'stroke-width': strokeW });
+      if (textEl) styleEl(textEl, { fill: textCol });
     }
 
     // --- Flowchart: nodes (g.node) — match by label text content ---
@@ -65,12 +66,8 @@ function applyDiffHighlights(svgStr: string, highlights: DiffHighlights): string
         const name = labelEl?.textContent?.trim() ?? '';
         if (!highlights.actors.has(name)) continue;
         const rect = group.querySelector('rect, polygon, circle, ellipse');
-        if (rect) {
-          rect.setAttribute('fill', fillBg);
-          rect.setAttribute('stroke', stroke);
-          rect.setAttribute('stroke-width', strokeW);
-        }
-        if (labelEl) (labelEl as HTMLElement).style.color = textCol;
+        if (rect) styleEl(rect, { fill: fillBg, stroke, 'stroke-width': strokeW });
+        if (labelEl) styleEl(labelEl, { color: textCol, fill: textCol });
       }
     }
 
@@ -85,11 +82,13 @@ function applyDiffHighlights(svgStr: string, highlights: DiffHighlights): string
       const label = msgEl.textContent?.trim() ?? '';
       if (!highlights.edgeLabels.has(label)) return;
       console.log('[BlueLens diff] MATCH found:', label);
-      msgEl.setAttribute('fill', textCol);
+      // Use inline style to override Mermaid's CSS class rules (e.g. .messageText { fill: black })
+      styleEl(msgEl, { fill: textCol });
+      // Also highlight tspan children which may inherit the class rule
+      msgEl.querySelectorAll('tspan').forEach(ts => styleEl(ts, { fill: textCol }));
       const line = allLines[idx];
       if (line) {
-        line.setAttribute('stroke', stroke);
-        line.setAttribute('stroke-width', strokeW);
+        styleEl(line, { stroke, 'stroke-width': strokeW });
       }
       // Fallback: scan backward siblings
       if (!line) {
@@ -99,8 +98,7 @@ function applyDiffHighlights(svgStr: string, highlights: DiffHighlights): string
         for (let k = i - 1; k >= 0; k--) {
           const el = children[k];
           if (el.tagName === 'line' || el.tagName === 'path') {
-            el.setAttribute('stroke', stroke);
-            el.setAttribute('stroke-width', strokeW);
+            styleEl(el, { stroke, 'stroke-width': strokeW });
             break;
           }
         }
@@ -113,13 +111,10 @@ function applyDiffHighlights(svgStr: string, highlights: DiffHighlights): string
         const label = labelEl.textContent?.trim() ?? '';
         if (!highlights.edgeLabels.has(label)) continue;
         console.log('[BlueLens diff] flowchart edge MATCH:', label);
-        (labelEl as HTMLElement).style.color = textCol;
+        styleEl(labelEl, { color: textCol, fill: textCol });
         // Try to find the associated path
         const edgeGroup = labelEl.closest('.edgePath, g');
-        edgeGroup?.querySelectorAll('path').forEach(p => {
-          p.setAttribute('stroke', stroke);
-          p.setAttribute('stroke-width', strokeW);
-        });
+        edgeGroup?.querySelectorAll('path').forEach(p => styleEl(p, { stroke, 'stroke-width': strokeW }));
       }
     }
 

--- a/components/SyncDiffModal.tsx
+++ b/components/SyncDiffModal.tsx
@@ -37,9 +37,11 @@ function applyDiffHighlights(svgStr: string, highlights: DiffHighlights): string
     if (!svg) return svgStr;
 
     const isAdded = highlights.mode === 'added';
-    const fillBg  = isAdded ? 'rgba(34,197,94,0.22)' : 'rgba(239,68,68,0.22)';
-    const stroke  = isAdded ? '#22c55e'               : '#ef4444';
-    const textCol = isAdded ? '#4ade80'               : '#f87171';
+    // Solid opaque fills override the node's original color entirely — no blending artifacts.
+    const fillBg  = isAdded ? '#dcfce7' : '#fee2e2';
+    const stroke  = isAdded ? '#16a34a' : '#dc2626';
+    const strokeW = '3';
+    const textCol = isAdded ? '#14532d' : '#7f1d1d';
 
     // --- Sequence: actors ---
     for (const group of svg.querySelectorAll('g.actor, g[class~="actor"]')) {
@@ -50,7 +52,7 @@ function applyDiffHighlights(svgStr: string, highlights: DiffHighlights): string
       if (rect) {
         rect.setAttribute('fill', fillBg);
         rect.setAttribute('stroke', stroke);
-        rect.setAttribute('stroke-width', '2.5');
+        rect.setAttribute('stroke-width', strokeW);
       }
       if (textEl) textEl.setAttribute('fill', textCol);
     }
@@ -66,7 +68,7 @@ function applyDiffHighlights(svgStr: string, highlights: DiffHighlights): string
         if (rect) {
           rect.setAttribute('fill', fillBg);
           rect.setAttribute('stroke', stroke);
-          rect.setAttribute('stroke-width', '2.5');
+          rect.setAttribute('stroke-width', strokeW);
         }
         if (labelEl) (labelEl as HTMLElement).style.color = textCol;
       }
@@ -87,7 +89,7 @@ function applyDiffHighlights(svgStr: string, highlights: DiffHighlights): string
       const line = allLines[idx];
       if (line) {
         line.setAttribute('stroke', stroke);
-        line.setAttribute('stroke-width', '3');
+        line.setAttribute('stroke-width', strokeW);
       }
       // Fallback: scan backward siblings
       if (!line) {
@@ -98,7 +100,7 @@ function applyDiffHighlights(svgStr: string, highlights: DiffHighlights): string
           const el = children[k];
           if (el.tagName === 'line' || el.tagName === 'path') {
             el.setAttribute('stroke', stroke);
-            el.setAttribute('stroke-width', '3');
+            el.setAttribute('stroke-width', strokeW);
             break;
           }
         }
@@ -116,7 +118,7 @@ function applyDiffHighlights(svgStr: string, highlights: DiffHighlights): string
         const edgeGroup = labelEl.closest('.edgePath, g');
         edgeGroup?.querySelectorAll('path').forEach(p => {
           p.setAttribute('stroke', stroke);
-          p.setAttribute('stroke-width', '3');
+          p.setAttribute('stroke-width', strokeW);
         });
       }
     }

--- a/components/SyncDiffModal.tsx
+++ b/components/SyncDiffModal.tsx
@@ -1,5 +1,7 @@
-import React, { useState } from 'react';
-import { GitBranch, Plus, Minus, Check, X, ChevronDown, ChevronRight, MessageSquare } from 'lucide-react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import { GitBranch, Plus, Minus, Check, X, ChevronDown, ChevronRight, MessageSquare, Maximize2, RotateCcw } from 'lucide-react';
+import mermaid from 'mermaid';
 import { SyncProposal, Diagram, DiagramDiff } from '../types';
 import { InlineDiagramPreview } from './InlineDiagramPreview';
 
@@ -10,6 +12,132 @@ interface SyncDiffModalProps {
   onDismiss: (proposalId: string) => void;
   onClose: () => void;
 }
+
+// ---------------------------------------------------------------------------
+// PanZoomDiagram — independent pan + zoom for each side of the visual diff
+// ---------------------------------------------------------------------------
+
+let _pzCounter = 0;
+
+const PanZoomDiagram: React.FC<{ code: string; label: string }> = ({ code, label }) => {
+  const [svg, setSvg] = useState('');
+  const [error, setError] = useState('');
+  const [t, setT] = useState({ x: 0, y: 0, scale: 1 });
+  const dragging = useRef(false);
+  const lastPos = useRef({ x: 0, y: 0 });
+  const containerRef = useRef<HTMLDivElement>(null);
+  const renderId = useRef(`pz-${++_pzCounter}`);
+
+  useEffect(() => {
+    if (!code.trim()) return;
+    let cancelled = false;
+    setSvg('');
+    setError('');
+    (async () => {
+      try {
+        const { svg: rendered } = await mermaid.render(renderId.current, code);
+        if (!cancelled) setSvg(rendered);
+      } catch (err: any) {
+        if (!cancelled) setError(err.message || 'Render error');
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [code]);
+
+  const onWheel = useCallback((e: React.WheelEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const factor = e.deltaY < 0 ? 1.12 : 0.9;
+    setT(prev => ({ ...prev, scale: Math.min(8, Math.max(0.15, prev.scale * factor)) }));
+  }, []);
+
+  const onMouseDown = useCallback((e: React.MouseEvent) => {
+    dragging.current = true;
+    lastPos.current = { x: e.clientX, y: e.clientY };
+  }, []);
+
+  const onMouseMove = useCallback((e: React.MouseEvent) => {
+    if (!dragging.current) return;
+    const dx = e.clientX - lastPos.current.x;
+    const dy = e.clientY - lastPos.current.y;
+    lastPos.current = { x: e.clientX, y: e.clientY };
+    setT(prev => ({ ...prev, x: prev.x + dx, y: prev.y + dy }));
+  }, []);
+
+  const onMouseUp = useCallback(() => { dragging.current = false; }, []);
+
+  const reset = () => setT({ x: 0, y: 0, scale: 1 });
+
+  return (
+    <div className="flex flex-col flex-1 min-w-0 border border-gray-700 rounded-lg overflow-hidden">
+      <div className="flex items-center justify-between px-3 py-2 bg-dark-800 border-b border-gray-700 shrink-0">
+        <span className="text-xs font-semibold text-gray-400 uppercase tracking-wider">{label}</span>
+        <button onClick={reset} className="p-1 rounded text-gray-500 hover:text-gray-300 transition-colors" title="Reset view">
+          <RotateCcw className="w-3 h-3" />
+        </button>
+      </div>
+      <div
+        ref={containerRef}
+        className="flex-1 overflow-hidden relative cursor-grab active:cursor-grabbing select-none bg-gray-950/60"
+        onWheel={onWheel}
+        onMouseDown={onMouseDown}
+        onMouseMove={onMouseMove}
+        onMouseUp={onMouseUp}
+        onMouseLeave={onMouseUp}
+      >
+        {error ? (
+          <div className="absolute inset-0 flex items-center justify-center text-red-400 text-xs">{error}</div>
+        ) : svg ? (
+          <div
+            className="absolute top-0 left-0 origin-top-left p-4 [&_svg]:max-w-none"
+            style={{ transform: `translate(${t.x}px,${t.y}px) scale(${t.scale})` }}
+            dangerouslySetInnerHTML={{ __html: svg }}
+          />
+        ) : (
+          <div className="absolute inset-0 flex items-center justify-center text-gray-600 text-xs">Rendering…</div>
+        )}
+        <div className="absolute bottom-2 right-2 text-[10px] text-gray-600 select-none pointer-events-none">
+          {Math.round(t.scale * 100)}%
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// DualDiagramModal — both diagrams side-by-side with independent pan/zoom
+// ---------------------------------------------------------------------------
+
+const DualDiagramModal: React.FC<{
+  diagramName: string;
+  currentCode: string;
+  proposedCode: string;
+  onClose: () => void;
+}> = ({ diagramName, currentCode, proposedCode, onClose }) => createPortal(
+  <div className="fixed inset-0 z-[200] flex items-center justify-center p-4">
+    <div className="absolute inset-0 bg-black/75 backdrop-blur-sm" onClick={onClose} />
+    <div className="relative w-full max-w-7xl h-[88vh] flex flex-col rounded-2xl bg-dark-900 border border-gray-700 shadow-2xl overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center justify-between px-5 py-3 border-b border-gray-700 shrink-0">
+        <span className="text-sm font-semibold text-gray-200">{diagramName} — Visual diff</span>
+        <div className="flex items-center gap-2 text-xs text-gray-500">
+          <span>Scroll to zoom · Drag to pan · Reset with ↺</span>
+          <button onClick={onClose} className="ml-3 p-1.5 rounded-lg hover:bg-dark-700 text-gray-500 hover:text-gray-300 transition-colors">
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+      {/* Side-by-side pan/zoom */}
+      <div className="flex-1 flex gap-3 p-3 min-h-0">
+        <PanZoomDiagram code={currentCode} label="Before" />
+        <PanZoomDiagram code={proposedCode} label="After" />
+      </div>
+    </div>
+  </div>,
+  document.body
+) as React.ReactElement;
+
+// ---------------------------------------------------------------------------
 
 function formatTimestamp(ts: number): string {
   const d = new Date(ts);
@@ -121,6 +249,7 @@ const DiagramDiffRow: React.FC<{
 }> = ({ diff, isSelected, onToggle }) => {
   const [expanded, setExpanded] = useState(true);
   const [showVisual, setShowVisual] = useState(true);
+  const [dualExpanded, setDualExpanded] = useState(false);
 
   const lineDiff = computeLineDiff(diff.currentCode, diff.proposedCode);
   const { added: addedLines, removed: removedLines } = summarizeLineDiff(lineDiff);
@@ -215,18 +344,39 @@ const DiagramDiffRow: React.FC<{
               Visual diff
             </button>
             {showVisual && (
-              <div className="grid grid-cols-2 gap-4 mt-2 min-h-[260px]">
-                <div className="flex flex-col">
-                  <p className="text-[10px] text-gray-500 font-semibold uppercase tracking-wider mb-1.5">Before</p>
-                  <div className="flex-1"><InlineDiagramPreview code={diff.currentCode} /></div>
+              <div
+                className="relative mt-2 min-h-[260px] cursor-zoom-in group"
+                onClick={() => setDualExpanded(true)}
+              >
+                <div className="grid grid-cols-2 gap-4 pointer-events-none">
+                  <div className="flex flex-col">
+                    <p className="text-[10px] text-gray-500 font-semibold uppercase tracking-wider mb-1.5">Before</p>
+                    <div className="flex-1"><InlineDiagramPreview code={diff.currentCode} /></div>
+                  </div>
+                  <div className="flex flex-col">
+                    <p className="text-[10px] text-gray-500 font-semibold uppercase tracking-wider mb-1.5">After</p>
+                    <div className="flex-1"><InlineDiagramPreview code={diff.annotatedCode} /></div>
+                  </div>
                 </div>
-                <div className="flex flex-col">
-                  <p className="text-[10px] text-gray-500 font-semibold uppercase tracking-wider mb-1.5">After</p>
-                  <div className="flex-1"><InlineDiagramPreview code={diff.annotatedCode} /></div>
+                {/* Invisible overlay — shows hint on hover */}
+                <div className="absolute inset-0 rounded-lg transition-colors duration-150 group-hover:bg-brand-500/5 flex items-center justify-center">
+                  <div className="opacity-0 group-hover:opacity-100 transition-opacity duration-150 flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-dark-900/90 border border-gray-600 text-xs text-gray-300 shadow-lg pointer-events-none">
+                    <Maximize2 className="w-3.5 h-3.5" />
+                    Expand side-by-side
+                  </div>
                 </div>
               </div>
             )}
           </div>
+
+          {dualExpanded && (
+            <DualDiagramModal
+              diagramName={diff.diagramName}
+              currentCode={diff.currentCode}
+              proposedCode={diff.annotatedCode}
+              onClose={() => setDualExpanded(false)}
+            />
+          )}
 
           <CodeDiff lines={lineDiff} />
         </div>

--- a/components/SyncDiffModal.tsx
+++ b/components/SyncDiffModal.tsx
@@ -23,11 +23,14 @@ interface DiffHighlights {
   mode: 'added' | 'removed';
 }
 
-function applySequenceHighlights(svgStr: string, highlights: DiffHighlights): string {
-  if (!highlights.actors.size && !highlights.edgeLabels.size) return svgStr;
+function applyDiffHighlights(svgStr: string, highlights: DiffHighlights): string {
+  console.log('[BlueLens diff] applyDiffHighlights called, mode:', highlights.mode,
+    'actors:', [...highlights.actors], 'edgeLabels:', [...highlights.edgeLabels]);
+  if (!highlights.actors.size && !highlights.edgeLabels.size) {
+    console.log('[BlueLens diff] nothing to highlight, returning as-is');
+    return svgStr;
+  }
   try {
-    // Use innerHTML (HTML parser) — more robust than DOMParser('image/svg+xml')
-    // which fails on Mermaid's not-quite-valid XML output.
     const container = document.createElement('div');
     container.innerHTML = svgStr;
     const svg = container.querySelector('svg');
@@ -38,9 +41,8 @@ function applySequenceHighlights(svgStr: string, highlights: DiffHighlights): st
     const stroke  = isAdded ? '#22c55e'               : '#ef4444';
     const textCol = isAdded ? '#4ade80'               : '#f87171';
 
-    // --- Actors ---
+    // --- Sequence: actors ---
     for (const group of svg.querySelectorAll('g.actor, g[class~="actor"]')) {
-      // The display label is in the deepest text-like node
       const textEl = group.querySelector('text') ?? group.querySelector('span');
       const name = textEl?.textContent?.trim() ?? '';
       if (!highlights.actors.has(name)) continue;
@@ -53,30 +55,44 @@ function applySequenceHighlights(svgStr: string, highlights: DiffHighlights): st
       if (textEl) textEl.setAttribute('fill', textCol);
     }
 
-    // --- Messages ---
-    // Collect all messageLine elements and messageText elements in DOM order.
-    // In Mermaid sequence SVGs they appear as flat siblings: line then text, interleaved.
+    // --- Flowchart: nodes (g.node) — match by label text content ---
+    if (highlights.actors.size > 0) {
+      for (const group of svg.querySelectorAll('g.node')) {
+        // Label is in a <span> inside foreignObject, or a <text> element
+        const labelEl = group.querySelector('span.nodeLabel, span, text');
+        const name = labelEl?.textContent?.trim() ?? '';
+        if (!highlights.actors.has(name)) continue;
+        const rect = group.querySelector('rect, polygon, circle, ellipse');
+        if (rect) {
+          rect.setAttribute('fill', fillBg);
+          rect.setAttribute('stroke', stroke);
+          rect.setAttribute('stroke-width', '2.5');
+        }
+        if (labelEl) (labelEl as HTMLElement).style.color = textCol;
+      }
+    }
+
+    // --- Sequence: messages ---
     const allLines = Array.from(svg.querySelectorAll('line[class*="messageLine"], path[class*="messageLine"]'));
     const allMsgTextEls = Array.from(svg.querySelectorAll('text[class*="messageText"]'));
 
-    console.debug('[BlueLens diff] highlight labels:', [...highlights.edgeLabels]);
-    console.debug('[BlueLens diff] messageLine count:', allLines.length, '| messageText count:', allMsgTextEls.length);
-    console.debug('[BlueLens diff] messageText contents:', allMsgTextEls.map(el => JSON.stringify(el.textContent?.trim())));
+    console.log('[BlueLens diff] messageLine count:', allLines.length, '| messageText count:', allMsgTextEls.length);
+    console.log('[BlueLens diff] messageText contents:', allMsgTextEls.map(el => JSON.stringify(el.textContent?.trim())));
 
     allMsgTextEls.forEach((msgEl, idx) => {
       const label = msgEl.textContent?.trim() ?? '';
       if (!highlights.edgeLabels.has(label)) return;
+      console.log('[BlueLens diff] MATCH found:', label);
       msgEl.setAttribute('fill', textCol);
-      // Associated line: same index, or scan backwards through siblings
       const line = allLines[idx];
       if (line) {
         line.setAttribute('stroke', stroke);
         line.setAttribute('stroke-width', '3');
       }
-      // Fallback: scan backward siblings for any line/path
-      const parent = msgEl.parentElement;
-      if (parent && !line) {
-        const children = Array.from(parent.children);
+      // Fallback: scan backward siblings
+      if (!line) {
+        const parent = msgEl.parentElement;
+        const children = parent ? Array.from(parent.children) : [];
         const i = children.indexOf(msgEl);
         for (let k = i - 1; k >= 0; k--) {
           const el = children[k];
@@ -88,6 +104,22 @@ function applySequenceHighlights(svgStr: string, highlights: DiffHighlights): st
         }
       }
     });
+
+    // --- Flowchart: edges — match edge labels ---
+    if (highlights.edgeLabels.size > 0) {
+      for (const labelEl of svg.querySelectorAll('.edgeLabel span, .edgeLabel text')) {
+        const label = labelEl.textContent?.trim() ?? '';
+        if (!highlights.edgeLabels.has(label)) continue;
+        console.log('[BlueLens diff] flowchart edge MATCH:', label);
+        (labelEl as HTMLElement).style.color = textCol;
+        // Try to find the associated path
+        const edgeGroup = labelEl.closest('.edgePath, g');
+        edgeGroup?.querySelectorAll('path').forEach(p => {
+          p.setAttribute('stroke', stroke);
+          p.setAttribute('stroke-width', '3');
+        });
+      }
+    }
 
     return container.innerHTML;
   } catch (e) {
@@ -119,7 +151,7 @@ const PanZoomDiagram: React.FC<{ code: string; label: string; highlights?: DiffH
     (async () => {
       try {
         const { svg: rendered } = await mermaid.render(renderId.current, code);
-        if (!cancelled) setSvg(highlights ? applySequenceHighlights(rendered, highlights) : rendered);
+        if (!cancelled) setSvg(highlights ? applyDiffHighlights(rendered, highlights) : rendered);
       } catch (err: any) {
         if (!cancelled) setError(err.message || 'Render error');
       }
@@ -364,8 +396,8 @@ const DiagramDiffRow: React.FC<{
     edgeLabels: new Set(diff.addedEdges.map(e => e.label).filter((l): l is string => !!l)),
     mode: 'added',
   };
-  const beforePostProcess = useCallback((svg: string) => applySequenceHighlights(svg, beforeHighlights), [diff.removedNodes, diff.removedEdges]); // eslint-disable-line
-  const afterPostProcess = useCallback((svg: string) => applySequenceHighlights(svg, afterHighlights), [diff.addedNodes, diff.addedEdges]); // eslint-disable-line
+  const beforePostProcess = useCallback((svg: string) => applyDiffHighlights(svg, beforeHighlights), [diff.removedNodes, diff.removedEdges]); // eslint-disable-line
+  const afterPostProcess = useCallback((svg: string) => applyDiffHighlights(svg, afterHighlights), [diff.addedNodes, diff.addedEdges]); // eslint-disable-line
 
   return (
     <div className="border border-gray-700 rounded-lg overflow-hidden">

--- a/services/diagramSyncService.ts
+++ b/services/diagramSyncService.ts
@@ -521,14 +521,15 @@ export function renderDiffAnnotated(
   // classDef / ::: annotations only work for flowchart/graph diagrams
   if (!supportsClassDef(proposedCode)) return proposedCode;
 
+  // "After" diagram: only highlight added nodes in green.
+  // Removed nodes are NOT added back as ghost nodes — they're already shown
+  // in red in the "Before" diagram via SVG post-processing.
   const lines: string[] = [];
   const addedClassDef = 'classDef added fill:#16a34a,color:#fff,stroke:#15803d';
-  const removedClassDef = 'classDef removed fill:#dc2626,color:#fff,stroke:#b91c1c';
 
   const proposedLines = proposedCode.split('\n');
   lines.push(proposedLines[0]);
   lines.push(`  ${addedClassDef}`);
-  lines.push(`  ${removedClassDef}`);
 
   const parsedNodes = parseMermaidNodes(proposedCode);
 
@@ -544,11 +545,6 @@ export function renderDiffAnnotated(
       }
     }
     if (!annotated) lines.push(line);
-  }
-
-  for (const label of removedLabels) {
-    const safeId = sanitizeMermaidId(label);
-    lines.push(`  ${safeId}["${escapeLabel(label)}"]:::removed`);
   }
 
   return lines.join('\n');

--- a/services/diagramSyncService.ts
+++ b/services/diagramSyncService.ts
@@ -397,6 +397,7 @@ For sequenceDiagrams, treat D3 changes with the same urgency as same-depth chang
 If you decide NO update is needed, respond with exactly: NO_CHANGE
 
 If an update IS needed, apply MINIMAL SURGICAL changes to the existing diagram:
+- CRITICAL: NEVER change the diagram type. If the original starts with "sequenceDiagram", the updated version MUST also start with "sequenceDiagram". If it starts with "flowchart", it must stay "flowchart". Changing the diagram type is STRICTLY FORBIDDEN.
 - DO NOT restructure or rewrite the diagram — start from the existing code and make targeted edits only
 - DO NOT rename existing nodes — preserve all existing node IDs and labels exactly as they are
 - DO NOT remove existing connections (edges) unless they reference a deleted entity from the diff
@@ -478,10 +479,20 @@ Decide: does this diagram need updating given the changes above? If not, respond
     }
 
     const extracted = extractMermaidBlock(content);
-    if (extracted && extracted.length > 0) return { code: extracted, explanation };
+    const candidate = extracted && extracted.length > 0 ? extracted : (
+      content.startsWith('flowchart') || content.startsWith('graph ') || content.startsWith('sequenceDiagram')
+        ? codeContent : null
+    );
 
-    if (content.startsWith('flowchart') || content.startsWith('graph ') || content.startsWith('sequenceDiagram')) {
-      return { code: codeContent, explanation };
+    if (candidate) {
+      // Guard: reject if LLM changed the diagram type
+      const originalType = diagram.code.trim().split(/\s/)[0];
+      const proposedType = candidate.trim().split(/\s/)[0];
+      if (proposedType !== originalType) {
+        console.warn(`[diagramSync] LLM changed diagram type from "${originalType}" to "${proposedType}" — rejecting`);
+        return null;
+      }
+      return { code: candidate, explanation };
     }
   } catch (err) {
     console.warn('[diagramSyncService] LLM proposeDiagramUpdate failed, falling back to deterministic:', err);


### PR DESCRIPTION
## Summary
- Replaces single-diagram expand with a fullscreen side-by-side modal (Before / After)
- Each diagram renders at full native size with independent wheel zoom and drag-to-pan
- Reset button per side, zoom % indicator
- Invisible clickable overlay covers the diff grid — hover reveals a centered hint tooltip, cursor becomes zoom-in — click anywhere to expand
- **Visual diff highlights**: removed elements in red (Before), added elements in green (After), for both sequence diagrams (actors + message arrows) and flowcharts (nodes + edges)
- **Fix**: inline `element.style.setProperty()` used instead of `setAttribute()` so highlights win over Mermaid's embedded `<style>` block (CSS specificity fix)

## Test plan
- [ ] Open a sync proposal with at least one diagram diff
- [ ] Hover over the Before/After grid — hint tooltip appears centered
- [ ] Click grid → fullscreen modal opens with both diagrams
- [ ] Scroll on each side independently to zoom
- [ ] Drag each side independently to pan
- [ ] ↺ resets view per side
- [ ] Click backdrop or X to close
- [ ] Removed elements appear in red in Before diagram
- [ ] Added elements appear in green in After diagram
- [ ] No red ghost nodes appear in After diagram

🤖 Generated with [Claude Code](https://claude.com/claude-code)